### PR TITLE
Expand international competition support

### DIFF
--- a/docs/bot-health.md
+++ b/docs/bot-health.md
@@ -61,8 +61,9 @@ Além do health-check automático, recomenda-se:
 
 ## 6. Cobertura de competições e APIs grátis
 
-- A tool `fetchFootballMatches` suporta automaticamente as ligas e taças listadas pelo utilizador, distribuídas por Europa, América do Sul, América do Norte, Ásia/Médio Oriente e África. O resumo diário apresenta os totais e destaques por região, garantindo que cada grupo recebe pelo menos três recomendações sempre que existam odds disponíveis.
-- O monitoramento ao vivo (`monitor-live-matches` + `live-betting-workflow`) usa o mesmo filtro de competições, pelo que os alertas consideram campeonatos e taças globais.
+- A tool `fetchFootballMatches` suporta automaticamente as ligas e taças listadas pelo utilizador, agora agrupadas por Europa, América do Sul, América do Norte, Ásia/Médio Oriente, África, competições continentais (UEFA Champions League, Libertadores, Champions Cup, etc.) e torneios mundiais (Mundial, Euro, Copa América, Jogos Olímpicos, Club World Cup). O resumo diário apresenta os totais e destaques por região, garantindo que cada grupo recebe pelo menos três recomendações sempre que existam odds disponíveis.
+- O monitoramento ao vivo (`monitor-live-matches` + `live-betting-workflow`) usa o mesmo filtro de competições, pelo que os alertas consideram campeonatos, torneios continentais e eventos globais sem ajustes adicionais.
+- Como a lista de torneios inclui fases finais com calendários intensivos, confirme se o `FOOTBALL_API_KEY` pertence a um plano com limite diário suficiente ou prepare chaves alternativas para períodos de Mundial, Jogos Olímpicos e outras fases concentradas. Ajuste também o cron ou janelas de execução para abranger partidas em fusos distintos (Ásia/Oceânia) durante esses eventos.
 - Todos os dados provêm do API-Football, que oferece um escalão gratuito suficiente para testes e para uma execução diária. Caso seja necessário reforçar o número de chamadas gratuitas para mercados específicos, prepare chaves adicionais de APIs públicas (por exemplo, API-FOOTBALL free tier adicional, Football-Data.org ou APIs federativas) e partilhe-as para integração futura.
 
 

--- a/src/mastra/constants/competitions.ts
+++ b/src/mastra/constants/competitions.ts
@@ -1,11 +1,16 @@
 import { z } from "zod";
 
-export type CompetitionRegion =
-  | "Europe"
-  | "South America"
-  | "North America"
-  | "Asia"
-  | "Africa";
+export const COMPETITION_REGIONS = [
+  "Europe",
+  "South America",
+  "North America",
+  "Asia",
+  "Africa",
+  "International",
+  "Intercontinental",
+] as const;
+
+export type CompetitionRegion = (typeof COMPETITION_REGIONS)[number];
 
 export type CompetitionType = "league" | "cup" | "supercup";
 
@@ -22,7 +27,7 @@ export interface CompetitionMetadata {
 export const competitionMetadataSchema = z.object({
   key: z.string(),
   displayName: z.string(),
-  region: z.enum(["Europe", "South America", "North America", "Asia", "Africa"]),
+  region: z.enum(COMPETITION_REGIONS),
   type: z.enum(["league", "cup", "supercup"]),
   country: z.string(),
   aliases: z.array(z.string()).optional(),
@@ -628,6 +633,213 @@ export const SUPPORTED_COMPETITIONS: CompetitionMetadata[] = [
     type: "cup",
     country: "Algeria",
   },
+
+  // International Club Competitions
+  {
+    key: "uefa-champions-league",
+    displayName: "UEFA Champions League",
+    region: "International",
+    type: "cup",
+    country: "UEFA",
+    aliases: [
+      "Champions League",
+      "Liga dos Campeões",
+      "UCL",
+      "World UEFA Champions League",
+    ],
+    apiFootballIds: [2],
+  },
+  {
+    key: "uefa-europa-league",
+    displayName: "UEFA Europa League",
+    region: "International",
+    type: "cup",
+    country: "UEFA",
+    aliases: ["Europa League", "Liga Europa", "UEL", "World UEFA Europa League"],
+    apiFootballIds: [3],
+  },
+  {
+    key: "uefa-europa-conference-league",
+    displayName: "UEFA Europa Conference League",
+    region: "International",
+    type: "cup",
+    country: "UEFA",
+    aliases: [
+      "Europa Conference League",
+      "Liga Conferência",
+      "UECL",
+      "World UEFA Conference League",
+    ],
+    apiFootballIds: [848],
+  },
+  {
+    key: "uefa-super-cup",
+    displayName: "UEFA Super Cup",
+    region: "International",
+    type: "supercup",
+    country: "UEFA",
+    aliases: ["Supertaça Europeia", "European Super Cup", "UEFA Supercup"],
+    apiFootballIds: [528],
+  },
+  {
+    key: "copa-libertadores",
+    displayName: "Copa Libertadores",
+    region: "International",
+    type: "cup",
+    country: "CONMEBOL",
+    aliases: ["CONMEBOL Libertadores", "Libertadores", "Taça Libertadores"],
+    apiFootballIds: [13],
+  },
+  {
+    key: "copa-sudamericana",
+    displayName: "Copa Sudamericana",
+    region: "International",
+    type: "cup",
+    country: "CONMEBOL",
+    aliases: ["CONMEBOL Sudamericana", "Sudamericana", "Copa Sul-Americana"],
+    apiFootballIds: [44],
+  },
+  {
+    key: "recopa-sudamericana",
+    displayName: "Recopa Sudamericana",
+    region: "International",
+    type: "supercup",
+    country: "CONMEBOL",
+    aliases: ["CONMEBOL Recopa", "Recopa", "Supercopa CONMEBOL"],
+    apiFootballIds: [215],
+  },
+  {
+    key: "concacaf-champions-cup",
+    displayName: "CONCACAF Champions Cup",
+    region: "International",
+    type: "cup",
+    country: "CONCACAF",
+    aliases: [
+      "CONCACAF Champions League",
+      "Liga dos Campeões CONCACAF",
+      "CCL",
+    ],
+    apiFootballIds: [32],
+  },
+  {
+    key: "leagues-cup",
+    displayName: "Leagues Cup",
+    region: "International",
+    type: "cup",
+    country: "CONCACAF",
+    aliases: ["Leagues Cup MLS", "Copa das Ligas", "MLS vs Liga MX"],
+    apiFootballIds: [719],
+  },
+  {
+    key: "afc-champions-league",
+    displayName: "AFC Champions League",
+    region: "International",
+    type: "cup",
+    country: "AFC",
+    aliases: ["Liga dos Campeões da AFC", "Asian Champions League", "ACL"],
+    apiFootballIds: [17],
+  },
+  {
+    key: "afc-cup",
+    displayName: "AFC Cup",
+    region: "International",
+    type: "cup",
+    country: "AFC",
+    aliases: ["Taça AFC", "AFC Cup", "Copa AFC"],
+    apiFootballIds: [18],
+  },
+  {
+    key: "caf-champions-league",
+    displayName: "CAF Champions League",
+    region: "International",
+    type: "cup",
+    country: "CAF",
+    aliases: ["Liga dos Campeões CAF", "African Champions League", "CAF CL"],
+    apiFootballIds: [10],
+  },
+  {
+    key: "caf-confederation-cup",
+    displayName: "CAF Confederation Cup",
+    region: "International",
+    type: "cup",
+    country: "CAF",
+    aliases: ["Taça das Confederações CAF", "CAF CC", "African Confederation Cup"],
+    apiFootballIds: [11],
+  },
+  {
+    key: "fifa-club-world-cup",
+    displayName: "FIFA Club World Cup",
+    region: "Intercontinental",
+    type: "cup",
+    country: "FIFA",
+    aliases: ["Mundial de Clubes", "Club World Cup", "FIFA CWC"],
+    apiFootballIds: [8],
+  },
+
+  // International & National Team Tournaments
+  {
+    key: "fifa-world-cup",
+    displayName: "FIFA World Cup",
+    region: "Intercontinental",
+    type: "cup",
+    country: "FIFA",
+    aliases: ["World Cup", "Mundial", "Copa do Mundo"],
+    apiFootballIds: [1],
+  },
+  {
+    key: "copa-america",
+    displayName: "Copa América",
+    region: "International",
+    type: "cup",
+    country: "CONMEBOL",
+    aliases: ["Copa America", "CONMEBOL Copa América", "Copa América de Seleções"],
+    apiFootballIds: [6],
+  },
+  {
+    key: "uefa-euro",
+    displayName: "UEFA Euro",
+    region: "International",
+    type: "cup",
+    country: "UEFA",
+    aliases: ["Euro", "European Championship", "Eurocopa"],
+    apiFootballIds: [4],
+  },
+  {
+    key: "africa-cup-of-nations",
+    displayName: "Africa Cup of Nations",
+    region: "International",
+    type: "cup",
+    country: "CAF",
+    aliases: ["Copa Africana de Nações", "CAN", "AFCON"],
+    apiFootballIds: [7],
+  },
+  {
+    key: "afc-asian-cup",
+    displayName: "AFC Asian Cup",
+    region: "International",
+    type: "cup",
+    country: "AFC",
+    aliases: ["Taça Asiática", "Asian Cup", "Copa da Ásia"],
+    apiFootballIds: [34],
+  },
+  {
+    key: "concacaf-gold-cup",
+    displayName: "CONCACAF Gold Cup",
+    region: "International",
+    type: "cup",
+    country: "CONCACAF",
+    aliases: ["Gold Cup", "Taça Ouro", "Copa Ouro"],
+    apiFootballIds: [24],
+  },
+  {
+    key: "olympic-games-football",
+    displayName: "Olympic Football Tournament",
+    region: "Intercontinental",
+    type: "cup",
+    country: "IOC",
+    aliases: ["Jogos Olímpicos", "Olympics Football", "Torneio Olímpico"],
+    apiFootballIds: [679],
+  },
 ];
 
 const normalizedCompetitions: NormalizedCompetition[] = SUPPORTED_COMPETITIONS.map(buildNormalizedCompetition);
@@ -643,6 +855,8 @@ export const REGION_ORDER: CompetitionRegion[] = [
   "North America",
   "Asia",
   "Africa",
+  "International",
+  "Intercontinental",
 ];
 
 export const REGION_LABEL: Record<CompetitionRegion, string> = {
@@ -651,6 +865,8 @@ export const REGION_LABEL: Record<CompetitionRegion, string> = {
   "North America": "América do Norte",
   Asia: "Ásia & Médio Oriente",
   Africa: "África",
+  International: "Competições Continentais",
+  Intercontinental: "Competições Mundiais",
 };
 
 export const identifyCompetition = (

--- a/src/mastra/tools/fetchFootballMatches.ts
+++ b/src/mastra/tools/fetchFootballMatches.ts
@@ -2,7 +2,13 @@ import { createTool } from "@mastra/core/tools";
 import type { IMastraLogger } from "@mastra/core/logger";
 import { z } from "zod";
 
-import { identifyCompetition, isCompetitionSupported, REGION_LABEL, REGION_ORDER } from "../constants/competitions";
+import {
+  COMPETITION_REGIONS,
+  identifyCompetition,
+  isCompetitionSupported,
+  REGION_LABEL,
+  REGION_ORDER,
+} from "../constants/competitions";
 
 const fetchFootballMatchesFromAPI = async ({
   date,
@@ -151,6 +157,10 @@ const fetchFootballMatchesFromAPI = async ({
           odds: odds,
         });
 
+        if (!regionCounters[competition.region]) {
+          regionCounters[competition.region] = { total: 0 };
+        }
+
         regionCounters[competition.region].total += 1;
 
         // Add small delay to avoid rate limiting
@@ -170,7 +180,7 @@ const fetchFootballMatchesFromAPI = async ({
       perRegion: REGION_ORDER.map((region) => ({
         region,
         label: REGION_LABEL[region],
-        total: regionCounters[region].total,
+        total: regionCounters[region]?.total ?? 0,
       })),
     });
 
@@ -185,7 +195,7 @@ const fetchFootballMatchesFromAPI = async ({
         perRegion: REGION_ORDER.map((region) => ({
           region,
           label: REGION_LABEL[region],
-          total: regionCounters[region].total,
+          total: regionCounters[region]?.total ?? 0,
         })),
       },
     };
@@ -219,7 +229,7 @@ export const fetchFootballMatchesTool = createTool({
       competition: z.object({
         key: z.string(),
         name: z.string(),
-        region: z.enum(["Europe", "South America", "North America", "Asia", "Africa"]),
+        region: z.enum(COMPETITION_REGIONS),
         type: z.enum(["league", "cup", "supercup"]),
         country: z.string(),
       }),
@@ -242,7 +252,7 @@ export const fetchFootballMatchesTool = createTool({
       processedFixtures: z.number(),
       perRegion: z.array(
         z.object({
-          region: z.enum(["Europe", "South America", "North America", "Asia", "Africa"]),
+          region: z.enum(COMPETITION_REGIONS),
           label: z.string(),
           total: z.number(),
         }),

--- a/src/mastra/tools/monitorLiveMatches.ts
+++ b/src/mastra/tools/monitorLiveMatches.ts
@@ -2,7 +2,13 @@ import { createTool } from "@mastra/core/tools";
 import type { IMastraLogger } from "@mastra/core/logger";
 import { z } from "zod";
 
-import { identifyCompetition, isCompetitionSupported, REGION_LABEL, REGION_ORDER } from "../constants/competitions";
+import {
+  COMPETITION_REGIONS,
+  identifyCompetition,
+  isCompetitionSupported,
+  REGION_LABEL,
+  REGION_ORDER,
+} from "../constants/competitions";
 
 const monitorLiveMatchesFromAPI = async ({
   logger,
@@ -206,6 +212,10 @@ const monitorLiveMatchesFromAPI = async ({
 
         liveMatches.push(match);
 
+        if (!regionCounters[competition.region]) {
+          regionCounters[competition.region] = { total: 0, high: 0, medium: 0 };
+        }
+
         const counters = regionCounters[competition.region];
         counters.total += 1;
         if (match.dangerLevel === "high") {
@@ -232,9 +242,9 @@ const monitorLiveMatchesFromAPI = async ({
       perRegion: REGION_ORDER.map((region) => ({
         region,
         label: REGION_LABEL[region],
-        total: regionCounters[region].total,
-        high: regionCounters[region].high,
-        medium: regionCounters[region].medium,
+        total: regionCounters[region]?.total ?? 0,
+        high: regionCounters[region]?.high ?? 0,
+        medium: regionCounters[region]?.medium ?? 0,
       })),
     });
 
@@ -251,9 +261,9 @@ const monitorLiveMatchesFromAPI = async ({
         perRegion: REGION_ORDER.map((region) => ({
           region,
           label: REGION_LABEL[region],
-          total: regionCounters[region].total,
-          high: regionCounters[region].high,
-          medium: regionCounters[region].medium,
+          total: regionCounters[region]?.total ?? 0,
+          high: regionCounters[region]?.high ?? 0,
+          medium: regionCounters[region]?.medium ?? 0,
         })),
       },
     };
@@ -283,7 +293,7 @@ export const monitorLiveMatchesTool = createTool({
       competition: z.object({
         key: z.string(),
         name: z.string(),
-        region: z.enum(["Europe", "South America", "North America", "Asia", "Africa"]),
+        region: z.enum(COMPETITION_REGIONS),
         type: z.enum(["league", "cup", "supercup"]),
         country: z.string(),
       }),
@@ -314,12 +324,12 @@ export const monitorLiveMatchesTool = createTool({
       totalFixtures: z.number(),
       supportedFixtures: z.number(),
       processedFixtures: z.number(),
-      perRegion: z.array(
-        z.object({
-          region: z.enum(["Europe", "South America", "North America", "Asia", "Africa"]),
-          label: z.string(),
-          total: z.number(),
-          high: z.number(),
+        perRegion: z.array(
+          z.object({
+            region: z.enum(COMPETITION_REGIONS),
+            label: z.string(),
+            total: z.number(),
+            high: z.number(),
           medium: z.number(),
         }),
       ),

--- a/src/mastra/workflows/footballPredictionsWorkflow.ts
+++ b/src/mastra/workflows/footballPredictionsWorkflow.ts
@@ -5,11 +5,12 @@ import { RuntimeContext } from "@mastra/core/di";
 import { fetchFootballMatchesTool } from "../tools/fetchFootballMatches";
 import { analyzeOddsAndMarketsTool } from "../tools/analyzeOddsAndMarkets";
 import { sendTelegramMessageTool } from "../tools/sendTelegramMessage";
+import { COMPETITION_REGIONS } from "../constants/competitions";
 
 const runtimeContext = new RuntimeContext();
 
 // Define common schemas for type safety
-const RegionEnum = z.enum(["Europe", "South America", "North America", "Asia", "Africa"]);
+const RegionEnum = z.enum(COMPETITION_REGIONS);
 
 const RegionBreakdown = z.object({
   region: RegionEnum,

--- a/src/mastra/workflows/liveBettingWorkflow.ts
+++ b/src/mastra/workflows/liveBettingWorkflow.ts
@@ -4,12 +4,12 @@ import { RuntimeContext } from "@mastra/core/di";
 
 import { monitorLiveMatchesTool } from "../tools/monitorLiveMatches";
 import { sendTelegramMessageTool } from "../tools/sendTelegramMessage";
-import { REGION_LABEL } from "../constants/competitions";
+import { COMPETITION_REGIONS, REGION_LABEL } from "../constants/competitions";
 
 const runtimeContext = new RuntimeContext();
 
 // Define schemas
-const RegionEnum = z.enum(["Europe", "South America", "North America", "Asia", "Africa"]);
+const RegionEnum = z.enum(COMPETITION_REGIONS);
 
 const LiveMatchData = z.object({
   totalLiveMatches: z.number(),


### PR DESCRIPTION
## Summary
- add continental and global tournaments to the football competition catalogue with aliases and API-Football ids
- expose the competition region list as a shared constant and extend region ordering/labels for International and Intercontinental groupings
- update tools and workflows to consume the expanded region enum and harden per-region summaries, plus refresh the bot health guide with the broader coverage

## Testing
- npm run check *(fails: missing local type declarations for Mastra/Inngest packages in repository configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b06d7d948325835a824cd18048ce