### PR TITLE
Add Python and Node self-hosting ports

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,14 @@
+# Self-hosting the Football Predictions Bot
+
+This repository now includes lightweight Python and Node.js ports of the Mastra workflow so you can run the bot on a regular VPS without the Mastra runtime.
+
+## Options
+
+| Stack | Entry point | Requirements |
+| --- | --- | --- |
+| Python | `python -m python_bot.main` | Python 3.11+, `requests`, `python-dotenv` |
+| Node.js | `node js_bot/index.js` | Node 20+ with global `fetch` |
+
+Both ports share the same competition metadata stored in `shared/competitions.json`, which is generated from the TypeScript source of the Mastra project. They expose similar CLI flags (`--env`, `--date`, `--dry-run`, `--chat-id`, `--output`) and expect the same environment variables.
+
+See the README files inside `python_bot/` and `js_bot/` for hands-on instructions.

--- a/js_bot/README.md
+++ b/js_bot/README.md
@@ -1,0 +1,32 @@
+# JavaScript Football Predictions Bot
+
+`js_bot/index.js` is a minimal Node.js port of the football predictions workflow. It reads the same `shared/competitions.json` catalogue and can run without the Mastra runtime so you can deploy it on any VPS with Node 20+.
+
+## Usage
+
+```bash
+node js_bot/index.js --env .env --dry-run
+```
+
+Available flags:
+
+- `--env <path>` – optional path to a `.env` file with API credentials
+- `--date YYYY-MM-DD` – fetch fixtures for a specific day (defaults to today)
+- `--dry-run` – print the Telegram message instead of sending it
+- `--chat-id` – override the destination chat
+- `--output <file>` – write a JSON summary to disk
+- `--verbose` – log extra information
+
+Required environment variables:
+
+```env
+FOOTBALL_API_KEY=your_api_sports_key
+TELEGRAM_BOT_TOKEN=your_bot_token
+# optional helpers
+TELEGRAM_DEFAULT_CHAT_ID=123456789
+TELEGRAM_CHANNEL_ID=@your_channel
+FOOTBALL_API_BOOKMAKER=6
+FOOTBALL_MAX_FIXTURES=120
+```
+
+The script relies on the global `fetch` available in Node 20. For older Node versions install a fetch polyfill or upgrade your runtime.

--- a/js_bot/index.js
+++ b/js_bot/index.js
@@ -1,0 +1,569 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function loadEnv(filePath) {
+  if (!filePath) return;
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) return;
+  const content = fs.readFileSync(resolved, 'utf-8');
+  for (const line of content.split(/\r?\n/)) {
+    if (!line || line.trim().startsWith('#')) continue;
+    const [key, ...rest] = line.split('=');
+    if (!key) continue;
+    const value = rest.join('=').trim();
+    if (!(key in process.env)) {
+      process.env[key.trim()] = value;
+    }
+  }
+}
+
+const competitionData = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../shared/competitions.json'), 'utf-8'),
+);
+
+const competitionsById = new Map();
+const aliasIndex = [];
+
+function normalize(value) {
+  if (!value) return null;
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/gi, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+for (const competition of competitionData.competitions) {
+  if (competition.apiFootballIds) {
+    for (const id of competition.apiFootballIds) {
+      competitionsById.set(id, competition);
+    }
+  }
+  const names = [
+    competition.displayName,
+    competition.country,
+    `${competition.country} ${competition.displayName}`,
+  ];
+  for (const alias of competition.aliases || []) {
+    names.push(alias);
+    names.push(`${competition.country} ${alias}`);
+  }
+  const normalized = new Set();
+  for (const name of names) {
+    const norm = normalize(name);
+    if (norm) normalized.add(norm);
+  }
+  aliasIndex.push({ aliases: normalized, competition });
+}
+
+function identifyCompetition(league) {
+  if (!league) return null;
+  if (typeof league.id === 'number' && competitionsById.has(league.id)) {
+    return competitionsById.get(league.id);
+  }
+  const name = normalize(league.name);
+  const country = normalize(league.country);
+  if (!name) return null;
+  for (const entry of aliasIndex) {
+    if (entry.aliases.has(name)) return entry.competition;
+    if (country && entry.aliases.has(`${country} ${name}`)) return entry.competition;
+  }
+  return null;
+}
+
+async function fetchJson(url, params, headers, timeout = 30000) {
+  const urlObj = new URL(url);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) {
+        urlObj.searchParams.set(key, value);
+      }
+    }
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  const response = await fetch(urlObj, { headers, signal: controller.signal });
+  clearTimeout(timer);
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+async function fetchMatches(date, settings, logger) {
+  const headers = {
+    'X-RapidAPI-Key': settings.footballApiKey,
+    'X-RapidAPI-Host': 'v3.football.api-sports.io',
+  };
+
+  logger.info(`Fetching fixtures for ${date}`);
+  const fixturesPayload = await fetchJson(
+    'https://v3.football.api-sports.io/fixtures',
+    { date, status: 'NS' },
+    headers,
+  );
+
+  const fixtures = fixturesPayload.response || [];
+  const supportedFixtures = fixtures.filter((fixture) => identifyCompetition(fixture.league));
+  const fixturesToProcess = supportedFixtures
+    .sort((a, b) => (a.fixture?.timestamp || 0) - (b.fixture?.timestamp || 0))
+    .slice(0, settings.maxFixtures);
+
+  const matches = [];
+  const regionCounters = Object.fromEntries(competitionData.regionOrder.map((region) => [region, 0]));
+
+  for (const fixture of fixturesToProcess) {
+    const competition = identifyCompetition(fixture.league);
+    if (!competition) continue;
+
+    const fixtureId = fixture.fixture?.id;
+    if (!fixtureId) continue;
+
+    let odds = [];
+    try {
+      const oddsPayload = await fetchJson(
+        'https://v3.football.api-sports.io/odds',
+        { fixture: fixtureId, bookmaker: settings.bookmakerId },
+        headers,
+      );
+      odds = oddsPayload.response?.[0]?.bookmakers?.[0]?.bets ?? [];
+    } catch (error) {
+      logger.warn(`Failed to fetch odds for fixture ${fixtureId}: ${error.message}`);
+    }
+
+    let time = '';
+    if (fixture.fixture?.date) {
+      try {
+        time = new Date(fixture.fixture.date).toLocaleTimeString('pt-PT', {
+          hour: '2-digit',
+          minute: '2-digit',
+        });
+      } catch {
+        time = fixture.fixture.date;
+      }
+    }
+
+    matches.push({
+      fixtureId,
+      date: fixture.fixture?.date,
+      time,
+      league: fixture.league,
+      competition: {
+        key: competition.key,
+        name: competition.displayName,
+        region: competition.region,
+        type: competition.type,
+        country: competition.country,
+      },
+      teams: fixture.teams,
+      venue: fixture.fixture?.venue?.name ?? 'TBD',
+      odds,
+    });
+
+    regionCounters[competition.region] = (regionCounters[competition.region] || 0) + 1;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  return {
+    date,
+    totalMatches: matches.length,
+    matches,
+    metadata: {
+      totalFixtures: fixtures.length,
+      supportedFixtures: supportedFixtures.length,
+      processedFixtures: fixturesToProcess.length,
+      perRegion: competitionData.regionOrder.map((region) => ({
+        region,
+        label: competitionData.regionLabel[region] || region,
+        total: regionCounters[region] || 0,
+      })),
+    },
+  };
+}
+
+function probabilityFromOdd(odd) {
+  const value = Number(odd);
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.round((1 / value) * 100);
+}
+
+function analyzeMatches(matches, logger) {
+  logger.info(`Analyzing ${matches.length} matches`);
+  const analyzed = matches.map((match) => {
+    const entry = {
+      ...match,
+      predictions: {
+        homeWinProbability: 0,
+        drawProbability: 0,
+        awayWinProbability: 0,
+        over25Probability: 0,
+        under25Probability: 0,
+        bttsYesProbability: 0,
+        bttsNoProbability: 0,
+      },
+      recommendedBets: [],
+      confidence: 'low',
+    };
+
+    const markets = new Map();
+    for (const market of match.odds || []) {
+      markets.set(market.name, market.values || []);
+    }
+
+    for (const value of markets.get('Match Winner') || []) {
+      if (value.value === 'Home') entry.predictions.homeWinProbability = probabilityFromOdd(value.odd);
+      if (value.value === 'Draw') entry.predictions.drawProbability = probabilityFromOdd(value.odd);
+      if (value.value === 'Away') entry.predictions.awayWinProbability = probabilityFromOdd(value.odd);
+    }
+
+    for (const value of markets.get('Goals Over/Under') || []) {
+      if (value.value === 'Over 2.5') entry.predictions.over25Probability = probabilityFromOdd(value.odd);
+      if (value.value === 'Under 2.5') entry.predictions.under25Probability = probabilityFromOdd(value.odd);
+    }
+
+    for (const value of markets.get('Both Teams Score') || []) {
+      if (value.value === 'Yes') entry.predictions.bttsYesProbability = probabilityFromOdd(value.odd);
+      if (value.value === 'No') entry.predictions.bttsNoProbability = probabilityFromOdd(value.odd);
+    }
+
+    const recommendations = [];
+    let confidenceScore = 0;
+    const maxProbability = Math.max(
+      entry.predictions.homeWinProbability,
+      entry.predictions.awayWinProbability,
+      entry.predictions.drawProbability,
+    );
+
+    if (maxProbability >= 70) {
+      const team =
+        entry.predictions.homeWinProbability >= entry.predictions.awayWinProbability
+          ? match.teams?.home?.name
+          : match.teams?.away?.name;
+      recommendations.push(`🏆 Forte favorito: ${team} (${maxProbability}%)`);
+      confidenceScore += 3;
+    } else if (maxProbability >= 55) {
+      const team =
+        entry.predictions.homeWinProbability >= entry.predictions.awayWinProbability
+          ? match.teams?.home?.name
+          : match.teams?.away?.name;
+      recommendations.push(`✅ Favorito: ${team} (${maxProbability}%)`);
+      confidenceScore += 2;
+    }
+
+    if (entry.predictions.over25Probability >= 60) {
+      recommendations.push(`⚽ Over 2.5 golos (${entry.predictions.over25Probability}%)`);
+      confidenceScore += 2;
+    } else if (entry.predictions.under25Probability >= 60) {
+      recommendations.push(`🛡️ Under 2.5 golos (${entry.predictions.under25Probability}%)`);
+      confidenceScore += 2;
+    }
+
+    if (entry.predictions.bttsYesProbability >= 60) {
+      recommendations.push(`🥅 Ambos marcam: SIM (${entry.predictions.bttsYesProbability}%)`);
+      confidenceScore += 1;
+    } else if (entry.predictions.bttsNoProbability >= 60) {
+      recommendations.push(`🚫 Ambos marcam: NÃO (${entry.predictions.bttsNoProbability}%)`);
+      confidenceScore += 1;
+    }
+
+    entry.recommendedBets = recommendations;
+    if (confidenceScore >= 5) entry.confidence = 'high';
+    else if (confidenceScore >= 3) entry.confidence = 'medium';
+    return entry;
+  });
+
+  const score = (match) => {
+    const base = { high: 3, medium: 2, low: 1 }[match.confidence] || 0;
+    return base * 10 + (match.recommendedBets?.length || 0);
+  };
+
+  const sorted = [...analyzed].sort((a, b) => score(b) - score(a));
+
+  const buckets = new Map();
+  for (const match of analyzed) {
+    const region = match.competition?.region;
+    if (!region) continue;
+    if (!buckets.has(region)) buckets.set(region, []);
+    buckets.get(region).push(match);
+  }
+
+  const breakdown = competitionData.regionOrder.map((region) => {
+    const matchesForRegion = buckets.get(region) || [];
+    return {
+      region,
+      label: competitionData.regionLabel[region] || region,
+      total: matchesForRegion.length,
+      highConfidence: matchesForRegion.filter((match) => match.confidence === 'high').length,
+      mediumConfidence: matchesForRegion.filter((match) => match.confidence === 'medium').length,
+    };
+  });
+
+  const bestByRegion = competitionData.regionOrder.map((region) => {
+    const matchesForRegion = buckets.get(region) || [];
+    const ordered = [...matchesForRegion].sort((a, b) => score(b) - score(a));
+    return {
+      region,
+      label: competitionData.regionLabel[region] || region,
+      matches: ordered.slice(0, 5),
+    };
+  });
+
+  return {
+    totalAnalyzed: analyzed.length,
+    bestMatches: sorted.slice(0, 10),
+    highConfidenceCount: sorted.filter((match) => match.confidence === 'high').length,
+    mediumConfidenceCount: sorted.filter((match) => match.confidence === 'medium').length,
+    breakdownByRegion: breakdown,
+    bestMatchesByRegion: bestByRegion,
+  };
+}
+
+function buildMessage(matchData, analysis) {
+  const date = new Date(matchData.date);
+  const formatted = date.toLocaleDateString('pt-PT', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  const lines = [];
+  lines.push(`🏆 <b>PREVISÕES FUTEBOL - ${formatted.toUpperCase()}</b>`);
+  lines.push('');
+  lines.push('📊 <b>Resumo Global:</b>');
+  lines.push(`• ${matchData.totalMatches} jogos elegíveis nas competições suportadas`);
+  lines.push(`• ${analysis.totalAnalyzed} jogos com odds válidas analisados`);
+  lines.push(
+    `• ${analysis.highConfidenceCount} jogos de alta confiança | ${analysis.mediumConfidenceCount} de média confiança`,
+  );
+  lines.push('');
+
+  const activeRegions = analysis.breakdownByRegion.filter((region) => region.total > 0);
+  if (activeRegions.length) {
+    lines.push('🌍 <b>Distribuição por Região:</b>');
+    for (const region of activeRegions) {
+      lines.push(`• ${region.label}: ${region.total} jogos (${region.highConfidence} alta | ${region.mediumConfidence} média)`);
+    }
+    lines.push('');
+  }
+
+  if (analysis.bestMatches.length) {
+    const highlights = analysis.bestMatches.slice(0, Math.min(5, analysis.bestMatches.length));
+    lines.push(`🔥 <b>TOP GLOBAL (${highlights.length})</b>`);
+    for (const match of highlights) {
+      const emoji = match.confidence === 'high' ? '🔥' : match.confidence === 'medium' ? '⚡' : '💡';
+      const competition = match.competition?.name || match.league?.name;
+      lines.push(`${emoji} <b>${match.teams?.home?.name} vs ${match.teams?.away?.name}</b> — ${competition}`);
+      if (match.time) {
+        lines.push(`⏰ ${match.time} | 🏆 ${match.league?.name}`);
+      }
+      if (match.recommendedBets?.length) {
+        lines.push(`🎯 ${match.recommendedBets.join(' | ')}`);
+      }
+      const predictions = match.predictions || {};
+      lines.push(
+        `📈 Prob: Casa ${predictions.homeWinProbability}% | Empate ${predictions.drawProbability}% | Fora ${predictions.awayWinProbability}%`,
+      );
+      lines.push('');
+    }
+  } else {
+    lines.push('😔 <b>Não há jogos com odds interessantes hoje.</b>');
+    lines.push('Voltamos amanhã com mais análises!');
+    lines.push('');
+    lines.push('📈 Tip: Verifique os jogos ao vivo durante o dia para oportunidades em tempo real.');
+  }
+
+  return lines.join('\n');
+}
+
+async function sendTelegram(message, settings, chatId, logger) {
+  const baseUrl = `https://api.telegram.org/bot${settings.telegramBotToken}`;
+
+  async function post(path, payload) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30000);
+    const response = await fetch(`${baseUrl}/${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!response.ok) {
+      throw new Error(`Telegram API error: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  async function getRecentChatId() {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30000);
+    const response = await fetch(`${baseUrl}/getUpdates?limit=10&offset=-10`, {
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!response.ok) return null;
+    const payload = await response.json();
+    for (const update of payload.result?.slice().reverse() || []) {
+      const chat = update.message?.chat;
+      if (chat?.type === 'private') {
+        return String(chat.id);
+      }
+    }
+    return null;
+  }
+
+  let targetChatId = chatId || process.env.TELEGRAM_DEFAULT_CHAT_ID;
+  if (!targetChatId) {
+    targetChatId = await getRecentChatId();
+  }
+
+  if (!targetChatId) {
+    throw new Error('Unable to determine Telegram chat id. Provide TELEGRAM_DEFAULT_CHAT_ID or send a message to the bot first.');
+  }
+
+  logger.info(`Sending Telegram message to ${targetChatId}`);
+  const privateResult = await post('sendMessage', {
+    chat_id: targetChatId,
+    text: message,
+    parse_mode: 'HTML',
+    disable_web_page_preview: true,
+  });
+
+  const results = [
+    {
+      type: 'private_chat',
+      success: true,
+      messageId: privateResult.result?.message_id,
+      chatId: targetChatId,
+    },
+  ];
+
+  if (settings.telegramChannelId) {
+    try {
+      const channelResult = await post('sendMessage', {
+        chat_id: settings.telegramChannelId,
+        text: message,
+        parse_mode: 'HTML',
+        disable_web_page_preview: true,
+      });
+      results.push({
+        type: 'channel',
+        success: true,
+        messageId: channelResult.result?.message_id,
+        chatId: settings.telegramChannelId,
+      });
+    } catch (error) {
+      logger.error(`Failed to send Telegram message to channel: ${error.message}`);
+    }
+  }
+
+  return {
+    success: true,
+    results,
+  };
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed = {
+    date: null,
+    env: null,
+    dryRun: false,
+    chatId: null,
+    output: null,
+    verbose: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--date') {
+      parsed.date = args[++i];
+    } else if (arg === '--env') {
+      parsed.env = args[++i];
+    } else if (arg === '--dry-run') {
+      parsed.dryRun = true;
+      i -= 1;
+    } else if (arg === '--chat-id') {
+      parsed.chatId = args[++i];
+    } else if (arg === '--output') {
+      parsed.output = args[++i];
+    } else if (arg === '--verbose') {
+      parsed.verbose = true;
+      i -= 1;
+    }
+  }
+
+  if (!parsed.date) {
+    parsed.date = new Date().toISOString().split('T')[0];
+  }
+
+  return parsed;
+}
+
+function createLogger(verbose) {
+  return {
+    info: (message) => {
+      console.log(`${new Date().toISOString()} INFO ${message}`);
+    },
+    warn: (message) => {
+      console.warn(`${new Date().toISOString()} WARN ${message}`);
+    },
+    error: (message) => {
+      console.error(`${new Date().toISOString()} ERROR ${message}`);
+    },
+  };
+}
+
+async function main() {
+  const args = parseArgs();
+  loadEnv(args.env);
+  const logger = createLogger(args.verbose);
+
+  const settings = {
+    footballApiKey: process.env.FOOTBALL_API_KEY,
+    telegramBotToken: process.env.TELEGRAM_BOT_TOKEN,
+    telegramChannelId: process.env.TELEGRAM_CHANNEL_ID,
+    bookmakerId: Number(process.env.FOOTBALL_API_BOOKMAKER || '6'),
+    maxFixtures: Number(process.env.FOOTBALL_MAX_FIXTURES || '120'),
+  };
+
+  if (!settings.footballApiKey) {
+    console.error('FOOTBALL_API_KEY is required');
+    process.exit(1);
+  }
+  if (!settings.telegramBotToken) {
+    console.error('TELEGRAM_BOT_TOKEN is required');
+    process.exit(1);
+  }
+
+  const matchData = await fetchMatches(args.date, settings, logger);
+  const analysis = analyzeMatches(matchData.matches, logger);
+  const message = buildMessage(matchData, analysis);
+
+  if (args.output) {
+    fs.writeFileSync(
+      path.resolve(args.output),
+      JSON.stringify({ matchData, analysis, message }, null, 2),
+      'utf-8',
+    );
+  }
+
+  if (args.dryRun) {
+    console.log(message);
+    return;
+  }
+
+  await sendTelegram(message, settings, args.chatId, logger);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/python_bot/README.md
+++ b/python_bot/README.md
@@ -1,0 +1,41 @@
+# Python Football Predictions Bot
+
+This directory contains a standalone Python port of the original Mastra workflow. It uses the same competition catalogue and reproduces the fetch → analyse → Telegram send pipeline so it can be hosted on a VPS or cron job without the Mastra runtime.
+
+## Quick start
+
+1. Create and fill a `.env` file with the required environment variables:
+
+```env
+FOOTBALL_API_KEY=your_api_sports_key
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+# Optional but recommended
+TELEGRAM_DEFAULT_CHAT_ID=123456789
+TELEGRAM_CHANNEL_ID=@your_channel
+FOOTBALL_API_BOOKMAKER=6
+FOOTBALL_MAX_FIXTURES=120
+```
+
+2. Install dependencies (Python 3.11+ recommended):
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r python_bot/requirements.txt
+```
+
+3. Run a dry run for today (no Telegram message is sent):
+
+```bash
+python -m python_bot.main --dry-run --env .env
+```
+
+4. Send the formatted predictions to Telegram:
+
+```bash
+python -m python_bot.main --env .env
+```
+
+Use `--date YYYY-MM-DD` to backfill a specific day, `--chat-id` to override the destination, and `--output` to export the raw JSON payload.
+
+The bot shares the competition metadata stored in `shared/competitions.json`, which is extracted directly from the TypeScript implementation.

--- a/python_bot/analyzer.py
+++ b/python_bot/analyzer.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+from .competitions import CompetitionIndex
+
+
+def _calculate_probability(odd: Optional[str]) -> int:
+    if not odd:
+        return 0
+    try:
+        value = float(odd)
+    except (TypeError, ValueError):
+        return 0
+    if value <= 0:
+        return 0
+    return round((1 / value) * 100)
+
+
+def analyze_matches(matches: List[Dict[str, object]], index: CompetitionIndex, logger: Optional[logging.Logger] = None) -> Dict[str, object]:
+    logger = logger or logging.getLogger(__name__)
+    logger.info("Analyzing matches", extra={"count": len(matches)})
+
+    analyzed: List[Dict[str, object]] = []
+
+    for match in matches:
+        entry = {
+            **match,
+            "predictions": {
+                "homeWinProbability": 0,
+                "drawProbability": 0,
+                "awayWinProbability": 0,
+                "over25Probability": 0,
+                "under25Probability": 0,
+                "bttsYesProbability": 0,
+                "bttsNoProbability": 0,
+            },
+            "recommendedBets": [],
+            "confidence": "low",
+        }
+
+        odds = match.get("odds") or []
+        if not odds:
+            analyzed.append(entry)
+            continue
+
+        market_lookup = {market.get("name"): market.get("values", []) for market in odds if isinstance(market, dict)}
+
+        match_winner = market_lookup.get("Match Winner", [])
+        over_under = market_lookup.get("Goals Over/Under", [])
+        btts = market_lookup.get("Both Teams Score", [])
+
+        predictions = entry["predictions"]
+
+        for value in match_winner:
+            label = value.get("value")
+            odd = value.get("odd")
+            if label == "Home":
+                predictions["homeWinProbability"] = _calculate_probability(odd)
+            elif label == "Draw":
+                predictions["drawProbability"] = _calculate_probability(odd)
+            elif label == "Away":
+                predictions["awayWinProbability"] = _calculate_probability(odd)
+
+        for value in over_under:
+            label = value.get("value")
+            odd = value.get("odd")
+            if label == "Over 2.5":
+                predictions["over25Probability"] = _calculate_probability(odd)
+            elif label == "Under 2.5":
+                predictions["under25Probability"] = _calculate_probability(odd)
+
+        for value in btts:
+            label = value.get("value")
+            odd = value.get("odd")
+            if label == "Yes":
+                predictions["bttsYesProbability"] = _calculate_probability(odd)
+            elif label == "No":
+                predictions["bttsNoProbability"] = _calculate_probability(odd)
+
+        recommendations: List[str] = []
+        confidence_score = 0
+
+        max_probability = max(predictions["homeWinProbability"], predictions["awayWinProbability"], predictions["drawProbability"])
+        if max_probability >= 70:
+            team = match.get("teams", {}).get("home", {}).get("name")
+            if predictions["awayWinProbability"] > predictions["homeWinProbability"]:
+                team = match.get("teams", {}).get("away", {}).get("name")
+            recommendations.append(f"🏆 Forte favorito: {team} ({max_probability}%)")
+            confidence_score += 3
+        elif max_probability >= 55:
+            team = match.get("teams", {}).get("home", {}).get("name")
+            if predictions["awayWinProbability"] > predictions["homeWinProbability"]:
+                team = match.get("teams", {}).get("away", {}).get("name")
+            recommendations.append(f"✅ Favorito: {team} ({max_probability}%)")
+            confidence_score += 2
+
+        if predictions["over25Probability"] >= 60:
+            recommendations.append(f"⚽ Over 2.5 golos ({predictions['over25Probability']}%)")
+            confidence_score += 2
+        elif predictions["under25Probability"] >= 60:
+            recommendations.append(f"🛡️ Under 2.5 golos ({predictions['under25Probability']}%)")
+            confidence_score += 2
+
+        if predictions["bttsYesProbability"] >= 60:
+            recommendations.append(f"🥅 Ambos marcam: SIM ({predictions['bttsYesProbability']}%)")
+            confidence_score += 1
+        elif predictions["bttsNoProbability"] >= 60:
+            recommendations.append(f"🚫 Ambos marcam: NÃO ({predictions['bttsNoProbability']}%)")
+            confidence_score += 1
+
+        entry["recommendedBets"] = recommendations
+
+        if confidence_score >= 5:
+            entry["confidence"] = "high"
+        elif confidence_score >= 3:
+            entry["confidence"] = "medium"
+
+        analyzed.append(entry)
+
+    confidence_rank = {"high": 3, "medium": 2, "low": 1}
+
+    def score(item: Dict[str, object]) -> int:
+        return confidence_rank.get(item.get("confidence", "low"), 0) * 10 + len(item.get("recommendedBets", []))
+
+    sorted_matches = sorted(analyzed, key=score, reverse=True)
+
+    buckets: Dict[str, List[Dict[str, object]]] = {region: [] for region in index.region_order}
+    for match in analyzed:
+        region = match.get("competition", {}).get("region")
+        if not isinstance(region, str):
+            continue
+        buckets.setdefault(region, []).append(match)
+
+    breakdown = []
+    for region in index.region_order:
+        matches_for_region = buckets.get(region, [])
+        breakdown.append(
+            {
+                "region": region,
+                "label": index.region_label.get(region, region),
+                "total": len(matches_for_region),
+                "highConfidence": sum(1 for match in matches_for_region if match.get("confidence") == "high"),
+                "mediumConfidence": sum(1 for match in matches_for_region if match.get("confidence") == "medium"),
+            }
+        )
+
+    best_by_region = []
+    for region in index.region_order:
+        matches_for_region = buckets.get(region, [])
+        ordered = sorted(matches_for_region, key=score, reverse=True)
+        best_by_region.append(
+            {
+                "region": region,
+                "label": index.region_label.get(region, region),
+                "matches": ordered[:5],
+            }
+        )
+
+    return {
+        "totalAnalyzed": len(analyzed),
+        "bestMatches": sorted_matches[:10],
+        "highConfidenceCount": sum(1 for match in sorted_matches if match.get("confidence") == "high"),
+        "mediumConfidenceCount": sum(1 for match in sorted_matches if match.get("confidence") == "medium"),
+        "breakdownByRegion": breakdown,
+        "bestMatchesByRegion": best_by_region,
+    }

--- a/python_bot/competitions.py
+++ b/python_bot/competitions.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+import unicodedata
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Competition:
+    key: str
+    display_name: str
+    region: str
+    type: str
+    country: str
+    aliases: List[str]
+    api_football_ids: List[int]
+
+
+@dataclass
+class CompetitionIndex:
+    competitions: List[Competition]
+    region_order: List[str]
+    region_label: Dict[str, str]
+
+    _aliases: List[tuple[set[str], Competition]]
+    _ids: Dict[int, Competition]
+
+    @staticmethod
+    def normalize(value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        normalized = unicodedata.normalize("NFD", value)
+        normalized = "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
+        normalized = " ".join(filter(None, [segment.strip() for segment in normalized.split()]))
+        return normalized.lower()
+
+    @classmethod
+    def from_json(cls, path: Path) -> "CompetitionIndex":
+        payload = json.loads(path.read_text())
+        competitions: List[Competition] = []
+        alias_index: List[tuple[set[str], Competition]] = []
+        id_index: Dict[int, Competition] = {}
+
+        for item in payload["competitions"]:
+            competition = Competition(
+                key=item["key"],
+                display_name=item["displayName"],
+                region=item["region"],
+                type=item["type"],
+                country=item["country"],
+                aliases=item.get("aliases", []),
+                api_football_ids=item.get("apiFootballIds", []),
+            )
+            competitions.append(competition)
+
+            names: List[str] = [competition.display_name, competition.country, f"{competition.country} {competition.display_name}"]
+            for alias in competition.aliases:
+                names.append(alias)
+                names.append(f"{competition.country} {alias}")
+
+            normalized_aliases = {alias for alias in (cls.normalize(name) for name in names) if alias}
+            alias_index.append((normalized_aliases, competition))
+
+            for identifier in competition.api_football_ids:
+                id_index[identifier] = competition
+
+        return cls(
+            competitions=competitions,
+            region_order=payload["regionOrder"],
+            region_label=payload["regionLabel"],
+            _aliases=alias_index,
+            _ids=id_index,
+        )
+
+    def identify(self, league: Optional[Dict[str, object]]) -> Optional[Competition]:
+        if not league:
+            return None
+
+        identifier = league.get("id")
+        if isinstance(identifier, int) and identifier in self._ids:
+            return self._ids[identifier]
+
+        name = self.normalize(league.get("name") if isinstance(league.get("name"), str) else None)
+        country = self.normalize(league.get("country") if isinstance(league.get("country"), str) else None)
+
+        if not name:
+            return None
+
+        for aliases, competition in self._aliases:
+            if name in aliases:
+                return competition
+            if country and f"{country} {name}" in aliases:
+                return competition
+
+        return None
+
+    def is_supported(self, league: Optional[Dict[str, object]]) -> bool:
+        return self.identify(league) is not None
+
+
+@lru_cache(maxsize=1)
+def load_index(base_path: Optional[Path] = None) -> CompetitionIndex:
+    if base_path is None:
+        base_path = Path(__file__).resolve().parent.parent / "shared"
+    data_path = base_path / "competitions.json"
+    return CompetitionIndex.from_json(data_path)

--- a/python_bot/config.py
+++ b/python_bot/config.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+
+
+@dataclass
+class Settings:
+    football_api_key: str
+    telegram_bot_token: str
+    telegram_channel_id: Optional[str]
+    default_chat_id: Optional[str]
+    bookmaker_id: int = 6
+    max_fixtures: int = 120
+
+
+def load_settings(env_file: Optional[Path] = None) -> Settings:
+    """Load settings from environment variables."""
+    load_dotenv(dotenv_path=env_file)
+
+    api_key = os.getenv("FOOTBALL_API_KEY")
+    if not api_key:
+        raise RuntimeError("FOOTBALL_API_KEY environment variable is required")
+
+    telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
+    if not telegram_token:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN environment variable is required")
+
+    channel_id = os.getenv("TELEGRAM_CHANNEL_ID")
+    default_chat = os.getenv("TELEGRAM_DEFAULT_CHAT_ID")
+    bookmaker = int(os.getenv("FOOTBALL_API_BOOKMAKER", "6"))
+    max_fixtures = int(os.getenv("FOOTBALL_MAX_FIXTURES", "120"))
+
+    return Settings(
+        football_api_key=api_key,
+        telegram_bot_token=telegram_token,
+        telegram_channel_id=channel_id,
+        default_chat_id=default_chat,
+        bookmaker_id=bookmaker,
+        max_fixtures=max_fixtures,
+    )

--- a/python_bot/fetcher.py
+++ b/python_bot/fetcher.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import requests
+
+from .competitions import CompetitionIndex
+from .config import Settings
+
+
+class FetchError(RuntimeError):
+    pass
+
+
+def fetch_matches(
+    date: datetime,
+    settings: Settings,
+    index: CompetitionIndex,
+    logger: Optional[logging.Logger] = None,
+) -> Dict[str, object]:
+    """Fetch fixtures and odds for the given date."""
+    iso_date = date.strftime("%Y-%m-%d")
+    headers = {
+        "X-RapidAPI-Key": settings.football_api_key,
+        "X-RapidAPI-Host": "v3.football.api-sports.io",
+    }
+
+    logger = logger or logging.getLogger(__name__)
+    logger.info("Fetching fixtures", extra={"date": iso_date})
+
+    fixtures_response = requests.get(
+        "https://v3.football.api-sports.io/fixtures",
+        params={"date": iso_date, "status": "NS"},
+        headers=headers,
+        timeout=30,
+    )
+    if fixtures_response.status_code != 200:
+        raise FetchError(f"Failed to fetch fixtures: {fixtures_response.status_code} {fixtures_response.text}")
+
+    payload = fixtures_response.json()
+    fixtures: List[Dict[str, object]] = payload.get("response", [])
+
+    supported_fixtures = [fixture for fixture in fixtures if index.is_supported(fixture.get("league"))]
+    fixtures_to_process = sorted(
+        supported_fixtures,
+        key=lambda fixture: fixture.get("fixture", {}).get("timestamp", 0) or 0,
+    )[: settings.max_fixtures]
+
+    logger.info(
+        "Processing fixtures",
+        extra={
+            "total": len(fixtures),
+            "supported": len(supported_fixtures),
+            "processing": len(fixtures_to_process),
+        },
+    )
+
+    region_counters = {region: 0 for region in index.region_order}
+    matches: List[Dict[str, object]] = []
+
+    for fixture in fixtures_to_process:
+        competition = index.identify(fixture.get("league"))
+        if not competition:
+            continue
+
+        fixture_info = fixture.get("fixture", {})
+        fixture_id = fixture_info.get("id")
+        if not fixture_id:
+            continue
+
+        odds_data = None
+        odds_response = requests.get(
+            "https://v3.football.api-sports.io/odds",
+            params={"fixture": fixture_id, "bookmaker": settings.bookmaker_id},
+            headers=headers,
+            timeout=30,
+        )
+        if odds_response.status_code == 200:
+            odds_payload = odds_response.json()
+            try:
+                odds_data = odds_payload["response"][0]["bookmakers"][0]["bets"]
+            except (KeyError, IndexError, TypeError):
+                odds_data = []
+        else:
+            logger.warning(
+                "Failed to fetch odds",
+                extra={"fixtureId": fixture_id, "status": odds_response.status_code},
+            )
+
+        date_str = fixture_info.get("date")
+        time_str = ""
+        if isinstance(date_str, str):
+            try:
+                dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+                time_str = dt.strftime("%H:%M")
+            except ValueError:
+                time_str = date_str
+
+        match_entry = {
+            "fixtureId": fixture_id,
+            "date": date_str,
+            "time": time_str,
+            "league": {
+                "name": fixture.get("league", {}).get("name"),
+                "country": fixture.get("league", {}).get("country"),
+                "logo": fixture.get("league", {}).get("logo"),
+            },
+            "competition": {
+                "key": competition.key,
+                "name": competition.display_name,
+                "region": competition.region,
+                "type": competition.type,
+                "country": competition.country,
+            },
+            "teams": {
+                "home": {
+                    "name": fixture.get("teams", {}).get("home", {}).get("name"),
+                    "logo": fixture.get("teams", {}).get("home", {}).get("logo"),
+                },
+                "away": {
+                    "name": fixture.get("teams", {}).get("away", {}).get("name"),
+                    "logo": fixture.get("teams", {}).get("away", {}).get("logo"),
+                },
+            },
+            "venue": fixture_info.get("venue", {}).get("name") or "TBD",
+            "odds": odds_data,
+        }
+
+        matches.append(match_entry)
+        region_counters[competition.region] = region_counters.get(competition.region, 0) + 1
+
+        time.sleep(0.1)
+
+    metadata = {
+        "totalFixtures": len(fixtures),
+        "supportedFixtures": len(supported_fixtures),
+        "processedFixtures": len(fixtures_to_process),
+        "perRegion": [
+            {
+                "region": region,
+                "label": index.region_label.get(region, region),
+                "total": region_counters.get(region, 0),
+            }
+            for region in index.region_order
+        ],
+    }
+
+    return {
+        "date": iso_date,
+        "totalMatches": len(matches),
+        "matches": matches,
+        "metadata": metadata,
+    }

--- a/python_bot/main.py
+++ b/python_bot/main.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from .analyzer import analyze_matches
+from .competitions import load_index
+from .config import load_settings
+from .fetcher import FetchError, fetch_matches
+from .message_builder import format_predictions_message
+from .telegram_client import TelegramClient
+
+
+def configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Standalone football predictions bot")
+    parser.add_argument("--date", help="Date in YYYY-MM-DD format", default=datetime.now(timezone.utc).strftime("%Y-%m-%d"))
+    parser.add_argument("--env", help="Path to .env file", default=None)
+    parser.add_argument("--dry-run", action="store_true", help="Skip sending message to Telegram")
+    parser.add_argument("--chat-id", help="Override Telegram chat id", default=None)
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    parser.add_argument("--output", help="Optional path to write JSON summary", default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    configure_logging(args.verbose)
+    logger = logging.getLogger("python-bot")
+
+    try:
+        date = datetime.fromisoformat(args.date)
+    except ValueError:
+        logger.error("Invalid date provided: %s", args.date)
+        return 1
+
+    try:
+        settings = load_settings(Path(args.env) if args.env else None)
+    except RuntimeError as exc:
+        logger.error("Configuration error: %s", exc)
+        return 1
+
+    index = load_index()
+
+    try:
+        match_data = fetch_matches(date, settings, index, logger=logger)
+    except FetchError as exc:
+        logger.error("Failed to fetch fixtures: %s", exc)
+        return 1
+
+    analysis = analyze_matches(match_data["matches"], index, logger=logger)
+    message = format_predictions_message(match_data, analysis)
+
+    result = {
+        "success": True,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "matchData": match_data,
+        "analysis": analysis,
+        "message": message,
+    }
+
+    if args.output:
+        Path(args.output).write_text(json.dumps(result, indent=2, ensure_ascii=False))
+
+    if args.dry_run:
+        print(message)
+    else:
+        client = TelegramClient(settings, logger=logger)
+        try:
+            send_result = client.send_message(message, chat_id=args.chat_id)
+            result["telegram"] = send_result
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to send Telegram message: %s", exc)
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python_bot/message_builder.py
+++ b/python_bot/message_builder.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict
+
+
+def format_predictions_message(match_data: Dict[str, object], analysis: Dict[str, object]) -> str:
+    date_str = match_data.get("date")
+    try:
+        formatted_date = datetime.fromisoformat(str(date_str)).strftime("%d/%m/%Y")
+    except Exception:
+        formatted_date = str(date_str)
+
+    message_lines = [f"🏆 <b>PREVISÕES FUTEBOL - {formatted_date}</b>", ""]
+
+    summary = [
+        "📊 <b>Resumo Global:</b>",
+        f"• {match_data.get('totalMatches', 0)} jogos elegíveis nas competições suportadas",
+        f"• {analysis.get('totalAnalyzed', 0)} jogos com odds válidas analisados",
+        f"• {analysis.get('highConfidenceCount', 0)} jogos de alta confiança | {analysis.get('mediumConfidenceCount', 0)} de média confiança",
+    ]
+    message_lines.extend(summary)
+    message_lines.append("")
+
+    breakdown = analysis.get("breakdownByRegion", [])
+    active_regions = [region for region in breakdown if region.get("total", 0) > 0]
+    if active_regions:
+        message_lines.append("🌍 <b>Distribuição por Região:</b>")
+        for region in active_regions:
+            label = region.get("label")
+            total = region.get("total", 0)
+            high = region.get("highConfidence", 0)
+            medium = region.get("mediumConfidence", 0)
+            message_lines.append(f"• {label}: {total} jogos ({high} alta | {medium} média)")
+        message_lines.append("")
+
+    best_matches = analysis.get("bestMatches", [])
+    if best_matches:
+        top_matches = best_matches[: min(5, len(best_matches))]
+        message_lines.append(f"🔥 <b>TOP GLOBAL ({len(top_matches)})</b>")
+        for match in top_matches:
+            confidence = match.get("confidence")
+            emoji = "🔥" if confidence == "high" else "⚡" if confidence == "medium" else "💡"
+            teams = match.get("teams", {})
+            competition = match.get("competition", {})
+            league_name = competition.get("name") or match.get("league", {}).get("name")
+            message_lines.append(
+                f"{emoji} <b>{teams.get('home', {}).get('name')} vs {teams.get('away', {}).get('name')}</b> — {league_name}"
+            )
+            if match.get("time"):
+                message_lines.append(f"⏰ {match['time']} | 🏆 {league_name}")
+            bets = match.get("recommendedBets", [])
+            if bets:
+                message_lines.append(f"🎯 {' | '.join(bets)}")
+            predictions = match.get("predictions", {})
+            if predictions:
+                message_lines.append(
+                    "📈 Prob: Casa {home}% | Empate {draw}% | Fora {away}%".format(
+                        home=predictions.get("homeWinProbability", 0),
+                        draw=predictions.get("drawProbability", 0),
+                        away=predictions.get("awayWinProbability", 0),
+                    )
+                )
+            message_lines.append("")
+    else:
+        message_lines.append("😔 <b>Não há jogos com odds interessantes hoje.</b>")
+        message_lines.append("Voltamos amanhã com mais análises!")
+        message_lines.append("")
+        message_lines.append("📈 Tip: Verifique os jogos ao vivo durante o dia para oportunidades em tempo real.")
+
+    return "\n".join(message_lines)

--- a/python_bot/requirements.txt
+++ b/python_bot/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv>=1.0.0
+requests>=2.32.0

--- a/python_bot/telegram_client.py
+++ b/python_bot/telegram_client.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Dict, Optional
+
+import requests
+
+from .config import Settings
+
+
+class TelegramClient:
+    def __init__(self, settings: Settings, logger: Optional[logging.Logger] = None) -> None:
+        self.settings = settings
+        self.logger = logger or logging.getLogger(__name__)
+
+    @property
+    def base_url(self) -> str:
+        return f"https://api.telegram.org/bot{self.settings.telegram_bot_token}"
+
+    def _post(self, method: str, payload: Dict[str, object]) -> Dict[str, object]:
+        response = requests.post(f"{self.base_url}/{method}", json=payload, timeout=30)
+        if response.status_code != 200:
+            raise RuntimeError(f"Telegram API error: {response.status_code} {response.text}")
+        return response.json()
+
+    def _get_recent_chat_id(self) -> Optional[str]:
+        try:
+            response = requests.get(f"{self.base_url}/getUpdates", params={"limit": 10, "offset": -10}, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning("Unable to fetch Telegram updates", exc_info=exc)
+            return None
+
+        for update in reversed(payload.get("result", [])):
+            message = update.get("message") or {}
+            chat = message.get("chat") or {}
+            if chat.get("type") == "private":
+                return str(chat.get("id"))
+        return None
+
+    def send_message(self, message: str, chat_id: Optional[str] = None) -> Dict[str, object]:
+        chat_id = chat_id or self.settings.default_chat_id or self._get_recent_chat_id()
+        if not chat_id:
+            raise RuntimeError("Unable to determine Telegram chat ID. Provide TELEGRAM_DEFAULT_CHAT_ID or send a message to the bot first.")
+
+        self.logger.info("Sending message to Telegram", extra={"chatId": chat_id, "length": len(message)})
+        main_result = self._post(
+            "sendMessage",
+            {
+                "chat_id": chat_id,
+                "text": message,
+                "parse_mode": "HTML",
+                "disable_web_page_preview": True,
+            },
+        )
+
+        results = [
+            {
+                "type": "private_chat",
+                "success": True,
+                "messageId": (main_result.get("result") or {}).get("message_id"),
+                "chatId": chat_id,
+            }
+        ]
+
+        if self.settings.telegram_channel_id:
+            try:
+                channel_result = self._post(
+                    "sendMessage",
+                    {
+                        "chat_id": self.settings.telegram_channel_id,
+                        "text": message,
+                        "parse_mode": "HTML",
+                        "disable_web_page_preview": True,
+                    },
+                )
+                results.append(
+                    {
+                        "type": "channel",
+                        "success": True,
+                        "messageId": (channel_result.get("result") or {}).get("message_id"),
+                        "chatId": self.settings.telegram_channel_id,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.logger.error("Failed to send message to Telegram channel", exc_info=exc)
+
+        return {
+            "success": True,
+            "messageId": results[0].get("messageId"),
+            "chatId": results[0].get("chatId"),
+            "sentAt": datetime.utcnow().isoformat(),
+            "results": results,
+        }

--- a/scripts/export_competitions.py
+++ b/scripts/export_competitions.py
@@ -1,0 +1,63 @@
+"""Export competition metadata from the TypeScript source into JSON.
+
+This helper mirrors the inline script used during the conversion so the
+shared competition catalogue can be regenerated without the Mastra build
+toolchain.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TS_FILE = ROOT / "src/mastra/constants/competitions.ts"
+OUTPUT = ROOT / "shared/competitions.json"
+
+
+def extract_competitions() -> dict:
+    source = TS_FILE.read_text(encoding="utf-8")
+
+    def extract(pattern: str) -> str:
+        match = re.search(pattern, source, re.S)
+        if not match:
+            raise RuntimeError(f"Pattern not found: {pattern}")
+        return match.group(1)
+
+    competitions_raw = extract(r"SUPPORTED_COMPETITIONS: CompetitionMetadata\[] = \[(.*?)]\s*;")
+    competitions_text = "[" + competitions_raw + "]"
+    competitions_text = re.sub(r"//.*", "", competitions_text)
+    competitions_text = re.sub(r"(\s*)([A-Za-z0-9_]+):", lambda match: f"{match.group(1)}\"{match.group(2)}\":", competitions_text)
+    competitions_text = re.sub(r",(\s*[}\]])", r"\1", competitions_text)
+    competitions = json.loads(competitions_text)
+
+    region_order_raw = extract(r"export const REGION_ORDER: CompetitionRegion\[] = \[(.*?)]\s*;")
+    region_order_text = "[" + region_order_raw + "]"
+    region_order_text = re.sub(r"//.*", "", region_order_text)
+    region_order_text = re.sub(r",(\s*[}\]])", r"\1", region_order_text)
+    region_order = json.loads(region_order_text)
+
+    region_label_raw = extract(r"export const REGION_LABEL: Record<CompetitionRegion, string> = \{(.*?)\}\s*;")
+    region_label_text = "{" + region_label_raw + "}"
+    region_label_text = re.sub(r"//.*", "", region_label_text)
+    region_label_text = re.sub(r"(\s*)([A-Za-z0-9_]+):", lambda match: f"{match.group(1)}\"{match.group(2)}\":", region_label_text)
+    region_label_text = re.sub(r",(\s*[}\]])", r"\1", region_label_text)
+    region_label = json.loads(region_label_text)
+
+    return {
+        "competitions": competitions,
+        "regionOrder": region_order,
+        "regionLabel": region_label,
+    }
+
+
+def main() -> None:
+    data = extract_competitions()
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"Wrote {len(data['competitions'])} competitions to {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/shared/competitions.json
+++ b/shared/competitions.json
@@ -1,0 +1,1022 @@
+{
+  "competitions": [
+    {
+      "key": "premier-league",
+      "displayName": "Premier League",
+      "region": "Europe",
+      "type": "league",
+      "country": "England",
+      "aliases": [
+        "English Premier League",
+        "EPL"
+      ],
+      "apiFootballIds": [
+        39
+      ]
+    },
+    {
+      "key": "la-liga",
+      "displayName": "La Liga",
+      "region": "Europe",
+      "type": "league",
+      "country": "Spain",
+      "aliases": [
+        "LaLiga",
+        "Primera Division"
+      ],
+      "apiFootballIds": [
+        140
+      ]
+    },
+    {
+      "key": "serie-a",
+      "displayName": "Serie A",
+      "region": "Europe",
+      "type": "league",
+      "country": "Italy",
+      "aliases": [
+        "Serie A TIM",
+        "Italian Serie A"
+      ],
+      "apiFootballIds": [
+        135
+      ]
+    },
+    {
+      "key": "bundesliga",
+      "displayName": "Bundesliga",
+      "region": "Europe",
+      "type": "league",
+      "country": "Germany",
+      "aliases": [
+        "1. Bundesliga"
+      ],
+      "apiFootballIds": [
+        78
+      ]
+    },
+    {
+      "key": "ligue-1",
+      "displayName": "Ligue 1",
+      "region": "Europe",
+      "type": "league",
+      "country": "France",
+      "aliases": [
+        "Ligue 1 Uber Eats"
+      ],
+      "apiFootballIds": [
+        61
+      ]
+    },
+    {
+      "key": "eredivisie",
+      "displayName": "Eredivisie",
+      "region": "Europe",
+      "type": "league",
+      "country": "Netherlands",
+      "aliases": [
+        "Dutch Eredivisie"
+      ],
+      "apiFootballIds": [
+        88
+      ]
+    },
+    {
+      "key": "primeira-liga",
+      "displayName": "Primeira Liga",
+      "region": "Europe",
+      "type": "league",
+      "country": "Portugal",
+      "aliases": [
+        "Liga Portugal"
+      ],
+      "apiFootballIds": [
+        94
+      ]
+    },
+    {
+      "key": "super-lig",
+      "displayName": "Super Lig",
+      "region": "Europe",
+      "type": "league",
+      "country": "Turkey",
+      "aliases": [
+        "Turkish Super Lig"
+      ],
+      "apiFootballIds": [
+        203
+      ]
+    },
+    {
+      "key": "belgian-pro-league",
+      "displayName": "Belgian Pro League",
+      "region": "Europe",
+      "type": "league",
+      "country": "Belgium",
+      "aliases": [
+        "Jupiler Pro League"
+      ],
+      "apiFootballIds": [
+        144
+      ]
+    },
+    {
+      "key": "scottish-premiership",
+      "displayName": "Scottish Premiership",
+      "region": "Europe",
+      "type": "league",
+      "country": "Scotland",
+      "aliases": [
+        "Scotland Premiership"
+      ],
+      "apiFootballIds": [
+        179
+      ]
+    },
+    {
+      "key": "russian-premier-league",
+      "displayName": "Russian Premier League",
+      "region": "Europe",
+      "type": "league",
+      "country": "Russia",
+      "aliases": [
+        "Russian Premier Liga",
+        "RPL"
+      ]
+    },
+    {
+      "key": "ukrainian-premier-league",
+      "displayName": "Ukrainian Premier League",
+      "region": "Europe",
+      "type": "league",
+      "country": "Ukraine",
+      "aliases": [
+        "UPL"
+      ]
+    },
+    {
+      "key": "taca-de-portugal",
+      "displayName": "Taça de Portugal",
+      "region": "Europe",
+      "type": "cup",
+      "country": "Portugal",
+      "aliases": [
+        "Taca de Portugal Placard"
+      ]
+    },
+    {
+      "key": "taca-da-liga-portugal",
+      "displayName": "Taça da Liga",
+      "region": "Europe",
+      "type": "cup",
+      "country": "Portugal",
+      "aliases": [
+        "Allianz Cup",
+        "League Cup Portugal"
+      ]
+    },
+    {
+      "key": "copa-del-rey",
+      "displayName": "Copa del Rey",
+      "region": "Europe",
+      "type": "cup",
+      "country": "Spain"
+    },
+    {
+      "key": "supercopa-espana",
+      "displayName": "Supercopa de España",
+      "region": "Europe",
+      "type": "supercup",
+      "country": "Spain",
+      "aliases": [
+        "Spanish Super Cup"
+      ]
+    },
+    {
+      "key": "fa-cup",
+      "displayName": "FA Cup",
+      "region": "Europe",
+      "type": "cup",
+      "country": "England",
+      "aliases": [
+        "Emirates FA Cup"
+      ],
+      "apiFootballIds": [
+        45
+      ]
+    },
+    {
+      "key": "efl-cup",
+      "displayName": "EFL Cup",
+      "region": "Europe",
+      "type": "cup",
+      "country": "England",
+      "aliases": [
+        "Carabao Cup",
+        "League Cup"
+      ],
+      "apiFootballIds": [
+        46
+      ]
+    },
+    {
+      "key": "dfb-pokal",
+      "displayName": "DFB-Pokal",
+      "region": "Europe",
+      "type": "cup",
+      "country": "Germany"
+    },
+    {
+      "key": "german-supercup",
+      "displayName": "Supercopa da Alemanha",
+      "region": "Europe",
+      "type": "supercup",
+      "country": "Germany",
+      "aliases": [
+        "DFL-Supercup"
+      ]
+    },
+    {
+      "key": "coppa-italia",
+      "displayName": "Coppa Italia",
+      "region": "Europe",
+      "type": "cup",
+      "country": "Italy"
+    },
+    {
+      "key": "supercoppa-italiana",
+      "displayName": "Supercoppa Italiana",
+      "region": "Europe",
+      "type": "supercup",
+      "country": "Italy"
+    },
+    {
+      "key": "coupe-de-france",
+      "displayName": "Coupe de France",
+      "region": "Europe",
+      "type": "cup",
+      "country": "France"
+    },
+    {
+      "key": "coupe-de-la-ligue",
+      "displayName": "Coupe de la Ligue",
+      "region": "Europe",
+      "type": "cup",
+      "country": "France",
+      "aliases": [
+        "French League Cup"
+      ]
+    },
+    {
+      "key": "trophee-des-champions",
+      "displayName": "Trophée des Champions",
+      "region": "Europe",
+      "type": "supercup",
+      "country": "France",
+      "aliases": [
+        "French Super Cup"
+      ]
+    },
+    {
+      "key": "knvb-beker",
+      "displayName": "KNVB Beker",
+      "region": "Europe",
+      "type": "cup",
+      "country": "Netherlands",
+      "aliases": [
+        "Dutch Cup"
+      ]
+    },
+    {
+      "key": "johan-cruyff-shield",
+      "displayName": "Johan Cruyff Shield",
+      "region": "Europe",
+      "type": "supercup",
+      "country": "Netherlands",
+      "aliases": [
+        "Dutch Super Cup",
+        "Supercopa da Holanda"
+      ]
+    },
+    {
+      "key": "turkey-cup",
+      "displayName": "Turkish Cup",
+      "region": "Europe",
+      "type": "cup",
+      "country": "Turkey",
+      "aliases": [
+        "Taça da Turquia",
+        "Türkiye Kupası"
+      ]
+    },
+    {
+      "key": "belgian-cup",
+      "displayName": "Belgian Cup",
+      "region": "Europe",
+      "type": "cup",
+      "country": "Belgium",
+      "aliases": [
+        "Taça da Bélgica",
+        "Croky Cup"
+      ]
+    },
+    {
+      "key": "scottish-cup",
+      "displayName": "Scottish Cup",
+      "region": "Europe",
+      "type": "cup",
+      "country": "Scotland"
+    },
+    {
+      "key": "scottish-league-cup",
+      "displayName": "Scottish League Cup",
+      "region": "Europe",
+      "type": "cup",
+      "country": "Scotland",
+      "aliases": [
+        "Viaplay Cup",
+        "Taça da Liga Escocesa"
+      ]
+    },
+    {
+      "key": "brasileirao-serie-a",
+      "displayName": "Brasileirão Série A",
+      "region": "South America",
+      "type": "league",
+      "country": "Brazil",
+      "aliases": [
+        "Serie A Brazil",
+        "Brasileirao"
+      ]
+    },
+    {
+      "key": "copa-do-brasil",
+      "displayName": "Copa do Brasil",
+      "region": "South America",
+      "type": "cup",
+      "country": "Brazil"
+    },
+    {
+      "key": "supercopa-do-brasil",
+      "displayName": "Supercopa do Brasil",
+      "region": "South America",
+      "type": "supercup",
+      "country": "Brazil"
+    },
+    {
+      "key": "liga-argentina",
+      "displayName": "Liga Profesional",
+      "region": "South America",
+      "type": "league",
+      "country": "Argentina",
+      "aliases": [
+        "Liga Argentina",
+        "Primera Division Argentina"
+      ]
+    },
+    {
+      "key": "copa-liga-argentina",
+      "displayName": "Copa de la Liga",
+      "region": "South America",
+      "type": "cup",
+      "country": "Argentina"
+    },
+    {
+      "key": "copa-argentina",
+      "displayName": "Copa Argentina",
+      "region": "South America",
+      "type": "cup",
+      "country": "Argentina"
+    },
+    {
+      "key": "supercopa-argentina",
+      "displayName": "Supercopa Argentina",
+      "region": "South America",
+      "type": "supercup",
+      "country": "Argentina"
+    },
+    {
+      "key": "campeonato-chileno",
+      "displayName": "Campeonato Chileno",
+      "region": "South America",
+      "type": "league",
+      "country": "Chile",
+      "aliases": [
+        "Primera División Chile"
+      ]
+    },
+    {
+      "key": "copa-chile",
+      "displayName": "Copa Chile",
+      "region": "South America",
+      "type": "cup",
+      "country": "Chile"
+    },
+    {
+      "key": "campeonato-uruguaio",
+      "displayName": "Campeonato Uruguaio",
+      "region": "South America",
+      "type": "league",
+      "country": "Uruguay",
+      "aliases": [
+        "Primera División Uruguay"
+      ]
+    },
+    {
+      "key": "copa-uruguay",
+      "displayName": "Copa Uruguay",
+      "region": "South America",
+      "type": "cup",
+      "country": "Uruguay"
+    },
+    {
+      "key": "campeonato-colombiano",
+      "displayName": "Liga BetPlay",
+      "region": "South America",
+      "type": "league",
+      "country": "Colombia",
+      "aliases": [
+        "Campeonato Colombiano"
+      ]
+    },
+    {
+      "key": "copa-colombia",
+      "displayName": "Copa Colombia",
+      "region": "South America",
+      "type": "cup",
+      "country": "Colombia"
+    },
+    {
+      "key": "campeonato-peruano",
+      "displayName": "Liga 1",
+      "region": "South America",
+      "type": "league",
+      "country": "Peru",
+      "aliases": [
+        "Liga Peruana"
+      ]
+    },
+    {
+      "key": "campeonato-paraguaio",
+      "displayName": "Primera División Paraguay",
+      "region": "South America",
+      "type": "league",
+      "country": "Paraguay",
+      "aliases": [
+        "Liga Paraguaya"
+      ]
+    },
+    {
+      "key": "campeonato-equatoriano",
+      "displayName": "Liga Pro Ecuador",
+      "region": "South America",
+      "type": "league",
+      "country": "Ecuador",
+      "aliases": [
+        "Liga Equatoriana"
+      ]
+    },
+    {
+      "key": "mls",
+      "displayName": "MLS",
+      "region": "North America",
+      "type": "league",
+      "country": "USA",
+      "aliases": [
+        "Major League Soccer"
+      ]
+    },
+    {
+      "key": "us-open-cup",
+      "displayName": "US Open Cup",
+      "region": "North America",
+      "type": "cup",
+      "country": "USA"
+    },
+    {
+      "key": "liga-mx",
+      "displayName": "Liga MX",
+      "region": "North America",
+      "type": "league",
+      "country": "Mexico"
+    },
+    {
+      "key": "copa-mx",
+      "displayName": "Copa MX",
+      "region": "North America",
+      "type": "cup",
+      "country": "Mexico",
+      "aliases": [
+        "Copa Mexico"
+      ]
+    },
+    {
+      "key": "campeones-cup",
+      "displayName": "Campeones Cup",
+      "region": "North America",
+      "type": "supercup",
+      "country": "Mexico",
+      "aliases": [
+        "Mexico vs USA Campeones Cup"
+      ]
+    },
+    {
+      "key": "saudi-pro-league",
+      "displayName": "Saudi Pro League",
+      "region": "Asia",
+      "type": "league",
+      "country": "Saudi Arabia"
+    },
+    {
+      "key": "kings-cup",
+      "displayName": "King's Cup",
+      "region": "Asia",
+      "type": "cup",
+      "country": "Saudi Arabia",
+      "aliases": [
+        "Kings Cup"
+      ]
+    },
+    {
+      "key": "qatar-stars-league",
+      "displayName": "Qatar Stars League",
+      "region": "Asia",
+      "type": "league",
+      "country": "Qatar"
+    },
+    {
+      "key": "copa-do-emir",
+      "displayName": "Copa do Emir",
+      "region": "Asia",
+      "type": "cup",
+      "country": "Qatar",
+      "aliases": [
+        "Emir Cup"
+      ]
+    },
+    {
+      "key": "uae-pro-league",
+      "displayName": "UAE Pro League",
+      "region": "Asia",
+      "type": "league",
+      "country": "United Arab Emirates",
+      "aliases": [
+        "Emirates League",
+        "UAE Arabian Gulf League"
+      ]
+    },
+    {
+      "key": "emirates-fa-cup-uae",
+      "displayName": "Emirates FA Cup",
+      "region": "Asia",
+      "type": "cup",
+      "country": "United Arab Emirates",
+      "aliases": [
+        "UAE President Cup"
+      ]
+    },
+    {
+      "key": "iran-pro-league",
+      "displayName": "Persian Gulf Pro League",
+      "region": "Asia",
+      "type": "league",
+      "country": "Iran",
+      "aliases": [
+        "Iran Pro League"
+      ]
+    },
+    {
+      "key": "j1-league",
+      "displayName": "J1 League",
+      "region": "Asia",
+      "type": "league",
+      "country": "Japan"
+    },
+    {
+      "key": "emperors-cup",
+      "displayName": "Emperor's Cup",
+      "region": "Asia",
+      "type": "cup",
+      "country": "Japan"
+    },
+    {
+      "key": "k-league-1",
+      "displayName": "K League 1",
+      "region": "Asia",
+      "type": "league",
+      "country": "South Korea"
+    },
+    {
+      "key": "fa-cup-korea",
+      "displayName": "Korean FA Cup",
+      "region": "Asia",
+      "type": "cup",
+      "country": "South Korea",
+      "aliases": [
+        "FA Cup Coreia do Sul"
+      ]
+    },
+    {
+      "key": "chinese-super-league",
+      "displayName": "Chinese Super League",
+      "region": "Asia",
+      "type": "league",
+      "country": "China"
+    },
+    {
+      "key": "china-fa-cup",
+      "displayName": "China FA Cup",
+      "region": "Asia",
+      "type": "cup",
+      "country": "China"
+    },
+    {
+      "key": "indian-super-league",
+      "displayName": "Indian Super League",
+      "region": "Asia",
+      "type": "league",
+      "country": "India"
+    },
+    {
+      "key": "india-super-cup",
+      "displayName": "India Super Cup",
+      "region": "Asia",
+      "type": "cup",
+      "country": "India"
+    },
+    {
+      "key": "egypt-cup",
+      "displayName": "Egypt Cup",
+      "region": "Africa",
+      "type": "cup",
+      "country": "Egypt"
+    },
+    {
+      "key": "moroccan-throne-cup",
+      "displayName": "Moroccan Throne Cup",
+      "region": "Africa",
+      "type": "cup",
+      "country": "Morocco"
+    },
+    {
+      "key": "nedbank-cup",
+      "displayName": "Nedbank Cup",
+      "region": "Africa",
+      "type": "cup",
+      "country": "South Africa",
+      "aliases": [
+        "South African Nedbank Cup"
+      ]
+    },
+    {
+      "key": "tunisian-cup",
+      "displayName": "Tunisian Cup",
+      "region": "Africa",
+      "type": "cup",
+      "country": "Tunisia"
+    },
+    {
+      "key": "algerian-cup",
+      "displayName": "Algerian Cup",
+      "region": "Africa",
+      "type": "cup",
+      "country": "Algeria"
+    },
+    {
+      "key": "uefa-champions-league",
+      "displayName": "UEFA Champions League",
+      "region": "International",
+      "type": "cup",
+      "country": "UEFA",
+      "aliases": [
+        "Champions League",
+        "Liga dos Campeões",
+        "UCL",
+        "World UEFA Champions League"
+      ],
+      "apiFootballIds": [
+        2
+      ]
+    },
+    {
+      "key": "uefa-europa-league",
+      "displayName": "UEFA Europa League",
+      "region": "International",
+      "type": "cup",
+      "country": "UEFA",
+      "aliases": [
+        "Europa League",
+        "Liga Europa",
+        "UEL",
+        "World UEFA Europa League"
+      ],
+      "apiFootballIds": [
+        3
+      ]
+    },
+    {
+      "key": "uefa-europa-conference-league",
+      "displayName": "UEFA Europa Conference League",
+      "region": "International",
+      "type": "cup",
+      "country": "UEFA",
+      "aliases": [
+        "Europa Conference League",
+        "Liga Conferência",
+        "UECL",
+        "World UEFA Conference League"
+      ],
+      "apiFootballIds": [
+        848
+      ]
+    },
+    {
+      "key": "uefa-super-cup",
+      "displayName": "UEFA Super Cup",
+      "region": "International",
+      "type": "supercup",
+      "country": "UEFA",
+      "aliases": [
+        "Supertaça Europeia",
+        "European Super Cup",
+        "UEFA Supercup"
+      ],
+      "apiFootballIds": [
+        528
+      ]
+    },
+    {
+      "key": "copa-libertadores",
+      "displayName": "Copa Libertadores",
+      "region": "International",
+      "type": "cup",
+      "country": "CONMEBOL",
+      "aliases": [
+        "CONMEBOL Libertadores",
+        "Libertadores",
+        "Taça Libertadores"
+      ],
+      "apiFootballIds": [
+        13
+      ]
+    },
+    {
+      "key": "copa-sudamericana",
+      "displayName": "Copa Sudamericana",
+      "region": "International",
+      "type": "cup",
+      "country": "CONMEBOL",
+      "aliases": [
+        "CONMEBOL Sudamericana",
+        "Sudamericana",
+        "Copa Sul-Americana"
+      ],
+      "apiFootballIds": [
+        44
+      ]
+    },
+    {
+      "key": "recopa-sudamericana",
+      "displayName": "Recopa Sudamericana",
+      "region": "International",
+      "type": "supercup",
+      "country": "CONMEBOL",
+      "aliases": [
+        "CONMEBOL Recopa",
+        "Recopa",
+        "Supercopa CONMEBOL"
+      ],
+      "apiFootballIds": [
+        215
+      ]
+    },
+    {
+      "key": "concacaf-champions-cup",
+      "displayName": "CONCACAF Champions Cup",
+      "region": "International",
+      "type": "cup",
+      "country": "CONCACAF",
+      "aliases": [
+        "CONCACAF Champions League",
+        "Liga dos Campeões CONCACAF",
+        "CCL"
+      ],
+      "apiFootballIds": [
+        32
+      ]
+    },
+    {
+      "key": "leagues-cup",
+      "displayName": "Leagues Cup",
+      "region": "International",
+      "type": "cup",
+      "country": "CONCACAF",
+      "aliases": [
+        "Leagues Cup MLS",
+        "Copa das Ligas",
+        "MLS vs Liga MX"
+      ],
+      "apiFootballIds": [
+        719
+      ]
+    },
+    {
+      "key": "afc-champions-league",
+      "displayName": "AFC Champions League",
+      "region": "International",
+      "type": "cup",
+      "country": "AFC",
+      "aliases": [
+        "Liga dos Campeões da AFC",
+        "Asian Champions League",
+        "ACL"
+      ],
+      "apiFootballIds": [
+        17
+      ]
+    },
+    {
+      "key": "afc-cup",
+      "displayName": "AFC Cup",
+      "region": "International",
+      "type": "cup",
+      "country": "AFC",
+      "aliases": [
+        "Taça AFC",
+        "AFC Cup",
+        "Copa AFC"
+      ],
+      "apiFootballIds": [
+        18
+      ]
+    },
+    {
+      "key": "caf-champions-league",
+      "displayName": "CAF Champions League",
+      "region": "International",
+      "type": "cup",
+      "country": "CAF",
+      "aliases": [
+        "Liga dos Campeões CAF",
+        "African Champions League",
+        "CAF CL"
+      ],
+      "apiFootballIds": [
+        10
+      ]
+    },
+    {
+      "key": "caf-confederation-cup",
+      "displayName": "CAF Confederation Cup",
+      "region": "International",
+      "type": "cup",
+      "country": "CAF",
+      "aliases": [
+        "Taça das Confederações CAF",
+        "CAF CC",
+        "African Confederation Cup"
+      ],
+      "apiFootballIds": [
+        11
+      ]
+    },
+    {
+      "key": "fifa-club-world-cup",
+      "displayName": "FIFA Club World Cup",
+      "region": "Intercontinental",
+      "type": "cup",
+      "country": "FIFA",
+      "aliases": [
+        "Mundial de Clubes",
+        "Club World Cup",
+        "FIFA CWC"
+      ],
+      "apiFootballIds": [
+        8
+      ]
+    },
+    {
+      "key": "fifa-world-cup",
+      "displayName": "FIFA World Cup",
+      "region": "Intercontinental",
+      "type": "cup",
+      "country": "FIFA",
+      "aliases": [
+        "World Cup",
+        "Mundial",
+        "Copa do Mundo"
+      ],
+      "apiFootballIds": [
+        1
+      ]
+    },
+    {
+      "key": "copa-america",
+      "displayName": "Copa América",
+      "region": "International",
+      "type": "cup",
+      "country": "CONMEBOL",
+      "aliases": [
+        "Copa America",
+        "CONMEBOL Copa América",
+        "Copa América de Seleções"
+      ],
+      "apiFootballIds": [
+        6
+      ]
+    },
+    {
+      "key": "uefa-euro",
+      "displayName": "UEFA Euro",
+      "region": "International",
+      "type": "cup",
+      "country": "UEFA",
+      "aliases": [
+        "Euro",
+        "European Championship",
+        "Eurocopa"
+      ],
+      "apiFootballIds": [
+        4
+      ]
+    },
+    {
+      "key": "africa-cup-of-nations",
+      "displayName": "Africa Cup of Nations",
+      "region": "International",
+      "type": "cup",
+      "country": "CAF",
+      "aliases": [
+        "Copa Africana de Nações",
+        "CAN",
+        "AFCON"
+      ],
+      "apiFootballIds": [
+        7
+      ]
+    },
+    {
+      "key": "afc-asian-cup",
+      "displayName": "AFC Asian Cup",
+      "region": "International",
+      "type": "cup",
+      "country": "AFC",
+      "aliases": [
+        "Taça Asiática",
+        "Asian Cup",
+        "Copa da Ásia"
+      ],
+      "apiFootballIds": [
+        34
+      ]
+    },
+    {
+      "key": "concacaf-gold-cup",
+      "displayName": "CONCACAF Gold Cup",
+      "region": "International",
+      "type": "cup",
+      "country": "CONCACAF",
+      "aliases": [
+        "Gold Cup",
+        "Taça Ouro",
+        "Copa Ouro"
+      ],
+      "apiFootballIds": [
+        24
+      ]
+    },
+    {
+      "key": "olympic-games-football",
+      "displayName": "Olympic Football Tournament",
+      "region": "Intercontinental",
+      "type": "cup",
+      "country": "IOC",
+      "aliases": [
+        "Jogos Olímpicos",
+        "Olympics Football",
+        "Torneio Olímpico"
+      ],
+      "apiFootballIds": [
+        679
+      ]
+    }
+  ],
+  "regionOrder": [
+    "Europe",
+    "South America",
+    "North America",
+    "Asia",
+    "Africa",
+    "International",
+    "Intercontinental"
+  ],
+  "regionLabel": {
+    "Europe": "Europa",
+    "South America": "América do Sul",
+    "North America": "América do Norte",
+    "Asia": "Ásia & Médio Oriente",
+    "Africa": "África",
+    "International": "Competições Continentais",
+    "Intercontinental": "Competições Mundiais"
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone `python_bot` package that fetches fixtures, analyses odds and sends Telegram updates without the Mastra runtime
- add a Node.js CLI in `js_bot/index.js` with matching functionality and documentation for VPS deployments
- extract the competition catalogue to `shared/competitions.json` with a helper script and self-hosting guide

## Testing
- python -m compileall python_bot
- node --check js_bot/index.js

------
https://chatgpt.com/codex/tasks/task_e_68d6b78bf488832595a6e46c78d11deb