### PR TITLE
Fix CLI argument parsing for Node bot

### DIFF
--- a/js_bot/index.js
+++ b/js_bot/index.js
@@ -481,22 +481,36 @@ function parseArgs() {
     verbose: false,
   };
 
+  const requireValue = (flag, value) => {
+    if (value === undefined) {
+      throw new Error(`Missing value for ${flag}`);
+    }
+    return value;
+  };
+
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
-    if (arg === '--date') {
-      parsed.date = args[++i];
-    } else if (arg === '--env') {
-      parsed.env = args[++i];
-    } else if (arg === '--dry-run') {
-      parsed.dryRun = true;
-      i -= 1;
-    } else if (arg === '--chat-id') {
-      parsed.chatId = args[++i];
-    } else if (arg === '--output') {
-      parsed.output = args[++i];
-    } else if (arg === '--verbose') {
-      parsed.verbose = true;
-      i -= 1;
+    switch (arg) {
+      case '--date':
+        parsed.date = requireValue('--date', args[++i]);
+        break;
+      case '--env':
+        parsed.env = requireValue('--env', args[++i]);
+        break;
+      case '--dry-run':
+        parsed.dryRun = true;
+        break;
+      case '--chat-id':
+        parsed.chatId = requireValue('--chat-id', args[++i]);
+        break;
+      case '--output':
+        parsed.output = requireValue('--output', args[++i]);
+        break;
+      case '--verbose':
+        parsed.verbose = true;
+        break;
+      default:
+        break;
     }
   }
 
@@ -522,7 +536,13 @@ function createLogger(verbose) {
 }
 
 async function main() {
-  const args = parseArgs();
+  let args;
+  try {
+    args = parseArgs();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
   loadEnv(args.env);
   const logger = createLogger(args.verbose);
 


### PR DESCRIPTION
## Summary
- fix infinite loop when parsing --dry-run and --verbose flags in the Node CLI
- validate required values for flags that expect parameters and handle parse errors gracefully in main

## Testing
- FOOTBALL_API_KEY=d TELEGRAM_BOT_TOKEN=t node js_bot/index.js --dry-run *(fails: network requests to the football API are blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e627fc72708325ac7f896419cac542