### PR TITLE
Add form-based insights and cron management docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Lembre-se: se o computador for desligado, o bot para. Para ficar online 24/7 use
 ## 5. Como a análise funciona
 
 * **Conversão de odds em probabilidade:** cada odd decimal é convertida em percentual (`100 / odd`).
+* **Form vs. histórico:** quando uma casa de apostas não oferece odds para 1X2, usamos o desempenho recente (últimos 5 jogos) e o confronto direto para estimar probabilidades, evitando relatórios zerados.
+* **Notas chave (PK):** para cada destaque são listados até 2 “pontos-chave” baseados na forma das equipas (sequência de vitórias/derrotas, média de golos, confrontos diretos).
 * **Classificação de confiança:** partidas com probabilidades altas geram recomendações "Forte favorito" ou "Favorito". Mercados Over/Under e Ambos Marcam entram na lista caso ultrapassem 60%.
 * **Pontuação e ordenação:** os jogos são reordenados por confiança e quantidade de recomendações, exibindo os melhores primeiro e organizando por região/competição.
 * **Resumo agregado:** o relatório mostra quantos jogos de alta ou média confiança existem por região, ajudando a priorizar ligas.
@@ -139,5 +141,44 @@ Para ver a lógica exata consulte:
 * Ajuste a lista de competições em `shared/competitions.json` para focar apenas nos campeonatos desejados.
 * Ajuste os thresholds de confiança no `analyzer.py` caso queira alertas mais conservadores ou agressivos.
 * Integre com outras saídas (Discord, e-mail) reutilizando a função `message_builder.build_message`.
+
+---
+
+## 7. Gerindo jobs agendados (cron/PM2)
+
+Quando precisar parar o bot para aplicar atualizações ou trocar credenciais, basta seguir os passos abaixo conforme a ferramenta usada:
+
+### Cron (Linux/macOS)
+
+1. **Listar o agendamento atual:**
+   ```bash
+   crontab -l
+   ```
+2. **Editar/pausar temporariamente:** comente a linha do bot adicionando `#` no início.
+   ```bash
+   crontab -e
+   # 0 9 * * * /caminho/para/.venv/bin/python -m python_bot.main --env /caminho/.env
+   ```
+3. **Aplicar a atualização (pull/commit/etc.)**
+4. **Reativar:** remova o `#` e salve novamente com `crontab -e`.
+
+### PM2 (Node.js)
+
+```bash
+# Parar o processo
+npx pm2 stop futebol-bot
+
+# Aplicar atualizações no código
+git pull
+npm install
+
+# Subir novamente (ajuste o comando conforme seu fluxo)
+npx pm2 start "node js_bot/index.js --env /caminho/.env" --name futebol-bot --cron "0 9 * * *"
+
+# Verificar status
+npx pm2 status futebol-bot
+```
+
+Para remover definitivamente um job agendado, use `crontab -e` (removendo a linha) ou `npx pm2 delete futebol-bot`. Depois de reinstalar dependências ou atualizar o código, execute os comandos de start novamente.
 
 Com esse guia você consegue hospedar o bot no seu PC, VPS ou Replit, mantendo as credenciais seguras e garantindo execuções automáticas confiáveis.

--- a/python_bot/analyzer.py
+++ b/python_bot/analyzer.py
@@ -1,9 +1,48 @@
 from __future__ import annotations
 
 import logging
+import re
+import unicodedata
 from typing import Dict, List, Optional
 
 from .competitions import CompetitionIndex
+
+
+HOME_LABELS = {"home", "1", "home team", "team 1", "1 home"}
+DRAW_LABELS = {"draw", "x", "empate"}
+AWAY_LABELS = {"away", "2", "away team", "team 2", "2 away"}
+YES_LABELS = {"yes", "sim", "y", "s"}
+NO_LABELS = {"no", "nao", "n"}
+
+
+def _normalize_label(value: Optional[object]) -> str:
+    if value is None:
+        return ""
+
+    text = str(value)
+    text = unicodedata.normalize("NFD", text)
+    text = "".join(ch for ch in text if unicodedata.category(ch) != "Mn")
+    text = text.replace(",", ".").replace("(", " ").replace(")", " ")
+    text = re.sub(r"\s+", " ", text)
+    return text.strip().lower()
+
+
+def _is_over_25_label(value: Optional[object]) -> bool:
+    normalized = _normalize_label(value)
+    if not normalized:
+        return False
+    if "over" in normalized or "mais de" in normalized:
+        return "2.5" in normalized or "25" in normalized
+    return False
+
+
+def _is_under_25_label(value: Optional[object]) -> bool:
+    normalized = _normalize_label(value)
+    if not normalized:
+        return False
+    if "under" in normalized or "menos de" in normalized:
+        return "2.5" in normalized or "25" in normalized
+    return False
 
 
 def _calculate_probability(odd: Optional[str]) -> int:
@@ -38,6 +77,7 @@ def analyze_matches(matches: List[Dict[str, object]], index: CompetitionIndex, l
             },
             "recommendedBets": [],
             "confidence": "low",
+            "analysisNotes": [],
         }
 
         odds = match.get("odds") or []
@@ -54,29 +94,29 @@ def analyze_matches(matches: List[Dict[str, object]], index: CompetitionIndex, l
         predictions = entry["predictions"]
 
         for value in match_winner:
-            label = value.get("value")
+            label = _normalize_label(value.get("value"))
             odd = value.get("odd")
-            if label == "Home":
+            if label in HOME_LABELS:
                 predictions["homeWinProbability"] = _calculate_probability(odd)
-            elif label == "Draw":
+            elif label in DRAW_LABELS:
                 predictions["drawProbability"] = _calculate_probability(odd)
-            elif label == "Away":
+            elif label in AWAY_LABELS:
                 predictions["awayWinProbability"] = _calculate_probability(odd)
 
         for value in over_under:
             label = value.get("value")
             odd = value.get("odd")
-            if label == "Over 2.5":
+            if _is_over_25_label(label):
                 predictions["over25Probability"] = _calculate_probability(odd)
-            elif label == "Under 2.5":
+            elif _is_under_25_label(label):
                 predictions["under25Probability"] = _calculate_probability(odd)
 
         for value in btts:
-            label = value.get("value")
+            label = _normalize_label(value.get("value"))
             odd = value.get("odd")
-            if label == "Yes":
+            if label in YES_LABELS:
                 predictions["bttsYesProbability"] = _calculate_probability(odd)
-            elif label == "No":
+            elif label in NO_LABELS:
                 predictions["bttsNoProbability"] = _calculate_probability(odd)
 
         recommendations: List[str] = []
@@ -109,6 +149,99 @@ def analyze_matches(matches: List[Dict[str, object]], index: CompetitionIndex, l
         elif predictions["bttsNoProbability"] >= 60:
             recommendations.append(f"🚫 Ambos marcam: NÃO ({predictions['bttsNoProbability']}%)")
             confidence_score += 1
+
+        notes: List[str] = []
+        qualitative_boost = 0
+
+        form_data = match.get("form") if isinstance(match, dict) else {}
+        home_form = (form_data or {}).get("home") if isinstance(form_data, dict) else None
+        away_form = (form_data or {}).get("away") if isinstance(form_data, dict) else None
+        head_to_head = (form_data or {}).get("headToHead") if isinstance(form_data, dict) else None
+
+        def _format_record(record: Optional[str]) -> str:
+            return (record or "")[:5]
+
+        if home_form and isinstance(home_form, dict):
+            streak = home_form.get("currentStreak", {})
+            if isinstance(streak, dict) and streak.get("type") == "win" and streak.get("count", 0) >= 3:
+                notes.append(
+                    f"Casa com {streak.get('count')} vitórias seguidas ({_format_record(home_form.get('recentRecord'))})"
+                )
+                qualitative_boost += 1
+
+        if away_form and isinstance(away_form, dict):
+            streak = away_form.get("currentStreak", {})
+            if isinstance(streak, dict) and streak.get("type") == "loss" and streak.get("count", 0) >= 2:
+                notes.append(
+                    f"Visitante sem vencer há {streak.get('count')} jogos ({_format_record(away_form.get('recentRecord'))})"
+                )
+                qualitative_boost += 1
+
+        avg_attack = 0.0
+        if home_form and isinstance(home_form, dict):
+            avg_attack += float(home_form.get("avgGoalsFor", 0.0))
+        if away_form and isinstance(away_form, dict):
+            avg_attack += float(away_form.get("avgGoalsFor", 0.0))
+
+        if avg_attack >= 3.2:
+            notes.append("Tendência de muitos golos (médias ofensivas altas nas últimas partidas)")
+        elif avg_attack <= 2.0:
+            notes.append("Tendência de poucos golos nos últimos jogos das equipas")
+
+        if head_to_head and isinstance(head_to_head, dict):
+            if int(head_to_head.get("homeWins", 0) or 0) >= 3:
+                notes.append("Histórico recente favorável ao mandante no confronto direto")
+                qualitative_boost += 1
+            if float(head_to_head.get("avgGoalsTotal", 0.0) or 0.0) >= 3:
+                notes.append("Confrontos diretos recentes com média superior a 3 golos")
+
+        draw_rate = (
+            float(home_form.get("drawRate", 0.0)) if isinstance(home_form, dict) else 0.0
+        ) + (
+            float(away_form.get("drawRate", 0.0)) if isinstance(away_form, dict) else 0.0
+        )
+        form_count = (1 if home_form else 0) + (1 if away_form else 0) or 1
+        draw_rate /= form_count
+
+        if (
+            predictions["homeWinProbability"] == 0
+            and predictions["awayWinProbability"] == 0
+            and predictions["drawProbability"] == 0
+            and (home_form or away_form)
+        ):
+            draw_probability = round(min(draw_rate, 0.45) * 100)
+
+            home_score = 0.0
+            away_score = 0.0
+            if isinstance(home_form, dict):
+                home_score += float(home_form.get("winRate", 0.0))
+                home_score += max(float(home_form.get("goalDifferenceAvg", 0.0)), 0)
+            if isinstance(away_form, dict):
+                home_score += float(away_form.get("lossRate", 0.0)) * 0.6
+
+            if isinstance(away_form, dict):
+                away_score += float(away_form.get("winRate", 0.0))
+                away_score += max(float(away_form.get("goalDifferenceAvg", 0.0)), 0)
+            if isinstance(home_form, dict):
+                away_score += float(home_form.get("lossRate", 0.0)) * 0.6
+
+            total_score = home_score + away_score
+            available = max(0, 100 - draw_probability)
+
+            if total_score > 0:
+                entry["predictions"]["homeWinProbability"] = round((home_score / total_score) * available)
+                entry["predictions"]["awayWinProbability"] = max(
+                    0,
+                    available - entry["predictions"]["homeWinProbability"],
+                )
+            else:
+                entry["predictions"]["homeWinProbability"] = round(available / 2)
+                entry["predictions"]["awayWinProbability"] = available - entry["predictions"]["homeWinProbability"]
+
+            entry["predictions"]["drawProbability"] = draw_probability
+
+        entry["analysisNotes"] = notes[:3]
+        confidence_score += qualitative_boost
 
         entry["recommendedBets"] = recommendations
 

--- a/python_bot/fetcher.py
+++ b/python_bot/fetcher.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import requests
 
@@ -13,6 +13,199 @@ from .config import Settings
 
 class FetchError(RuntimeError):
     pass
+
+
+def _extract_score(fixture: Dict[str, object]) -> Tuple[int, int]:
+    goals = fixture.get("goals") or {}
+    score = fixture.get("score") or {}
+    full_time = score.get("fulltime") or {}
+    extra_time = score.get("extratime") or {}
+    penalties = score.get("penalty") or {}
+
+    home = goals.get("home")
+    away = goals.get("away")
+
+    if home is None:
+        home = full_time.get("home") or extra_time.get("home") or penalties.get("home") or 0
+    if away is None:
+        away = full_time.get("away") or extra_time.get("away") or penalties.get("away") or 0
+
+    try:
+        return int(home), int(away)
+    except (TypeError, ValueError):
+        return 0, 0
+
+
+def _summarize_team_form(team_id: Optional[int], fixtures: List[Dict[str, object]]) -> Optional[Dict[str, object]]:
+    if not team_id or not fixtures:
+        return None
+
+    ordered = sorted(fixtures, key=lambda item: (item.get("fixture", {}) or {}).get("timestamp", 0) or 0, reverse=True)
+
+    matches: List[Dict[str, object]] = []
+    wins = draws = losses = goals_for = goals_against = clean_sheets = failed_to_score = 0
+
+    for fixture in ordered:
+        home_goals, away_goals = _extract_score(fixture)
+        teams = fixture.get("teams", {}) or {}
+        home_team = (teams.get("home") or {}).get("id")
+        away_team = (teams.get("away") or {}).get("id")
+        is_home = home_team == team_id
+        opponent = teams.get("away") if is_home else teams.get("home")
+
+        winner = None
+        home_winner = (teams.get("home") or {}).get("winner")
+        away_winner = (teams.get("away") or {}).get("winner")
+        if home_winner is True and away_winner is False:
+            winner = "home"
+        elif home_winner is False and away_winner is True:
+            winner = "away"
+        elif home_goals > away_goals:
+            winner = "home"
+        elif away_goals > home_goals:
+            winner = "away"
+        else:
+            winner = "draw"
+
+        result_code = "E" if winner == "draw" else ("V" if winner == ("home" if is_home else "away") else "D")
+
+        matches.append(
+            {
+                "fixtureId": (fixture.get("fixture") or {}).get("id"),
+                "date": (fixture.get("fixture") or {}).get("date"),
+                "opponent": (opponent or {}).get("name"),
+                "competition": (fixture.get("league") or {}).get("name"),
+                "score": f"{home_goals}-{away_goals}",
+                "result": result_code,
+            }
+        )
+
+        goals_for_match = home_goals if is_home else away_goals
+        goals_against_match = away_goals if is_home else home_goals
+
+        goals_for += goals_for_match
+        goals_against += goals_against_match
+
+        if result_code == "V":
+            wins += 1
+        elif result_code == "E":
+            draws += 1
+        else:
+            losses += 1
+
+        if goals_against_match == 0:
+            clean_sheets += 1
+        if goals_for_match == 0:
+            failed_to_score += 1
+
+    total = len(matches)
+    if total == 0:
+        return None
+
+    recent_record = "".join(match["result"] for match in matches)
+    first_result = matches[0]["result"]
+    streak_count = 0
+    for match in matches:
+        if match["result"] == first_result:
+            streak_count += 1
+        else:
+            break
+
+    streak_type = "draw"
+    if first_result == "V":
+        streak_type = "win"
+    elif first_result == "D":
+        streak_type = "loss"
+
+    avg_goals_for = round(goals_for / total, 2)
+    avg_goals_against = round(goals_against / total, 2)
+
+    return {
+        "sampleSize": total,
+        "matches": matches,
+        "wins": wins,
+        "draws": draws,
+        "losses": losses,
+        "winRate": wins / total if total else 0,
+        "drawRate": draws / total if total else 0,
+        "lossRate": losses / total if total else 0,
+        "formPoints": wins * 3 + draws,
+        "avgGoalsFor": avg_goals_for,
+        "avgGoalsAgainst": avg_goals_against,
+        "avgGoalsTotal": round((goals_for + goals_against) / total, 2),
+        "goalDifferenceAvg": round(avg_goals_for - avg_goals_against, 2),
+        "cleanSheets": clean_sheets,
+        "failedToScore": failed_to_score,
+        "recentRecord": recent_record,
+        "currentStreak": {"type": streak_type, "count": streak_count},
+    }
+
+
+def _summarize_head_to_head(home_id: Optional[int], away_id: Optional[int], fixtures: List[Dict[str, object]]) -> Optional[Dict[str, object]]:
+    if not home_id or not away_id or not fixtures:
+        return None
+
+    ordered = sorted(fixtures, key=lambda item: (item.get("fixture", {}) or {}).get("timestamp", 0) or 0, reverse=True)
+
+    matches: List[Dict[str, object]] = []
+    home_wins = away_wins = draws = 0
+    total_goals = 0
+
+    for fixture in ordered:
+        home_goals, away_goals = _extract_score(fixture)
+        teams = fixture.get("teams", {}) or {}
+        fixture_home = (teams.get("home") or {}).get("id")
+        upcoming_home_was_home = fixture_home == home_id
+
+        home_winner = (teams.get("home") or {}).get("winner")
+        away_winner = (teams.get("away") or {}).get("winner")
+
+        upcoming_home_won: Optional[bool]
+        if home_winner is True and away_winner is False:
+            upcoming_home_won = upcoming_home_was_home
+        elif home_winner is False and away_winner is True:
+            upcoming_home_won = not upcoming_home_was_home
+        elif home_goals > away_goals:
+            upcoming_home_won = upcoming_home_was_home
+        elif away_goals > home_goals:
+            upcoming_home_won = not upcoming_home_was_home
+        else:
+            upcoming_home_won = None
+
+        if upcoming_home_won is None:
+            result_code = "E"
+            draws += 1
+        elif upcoming_home_won:
+            result_code = "V"
+            home_wins += 1
+        else:
+            result_code = "D"
+            away_wins += 1
+
+        matches.append(
+            {
+                "fixtureId": (fixture.get("fixture") or {}).get("id"),
+                "date": (fixture.get("fixture") or {}).get("date"),
+                "venue": ((fixture.get("fixture") or {}).get("venue") or {}).get("name"),
+                "score": f"{home_goals}-{away_goals}",
+                "result": result_code,
+            }
+        )
+
+        total_goals += home_goals + away_goals
+
+    sample_size = len(matches)
+    if sample_size == 0:
+        return None
+
+    return {
+        "sampleSize": sample_size,
+        "matches": matches,
+        "homeWins": home_wins,
+        "awayWins": away_wins,
+        "draws": draws,
+        "avgGoalsTotal": round(total_goals / sample_size, 2),
+    }
 
 
 def fetch_matches(
@@ -61,6 +254,63 @@ def fetch_matches(
     region_counters = {region: 0 for region in index.region_order}
     matches: List[Dict[str, object]] = []
 
+    team_form_cache: Dict[int, Optional[Dict[str, object]]] = {}
+    head_to_head_cache: Dict[Tuple[int, int], Optional[Dict[str, object]]] = {}
+
+    def get_team_form(team_id: Optional[int]) -> Optional[Dict[str, object]]:
+        if not team_id:
+            return None
+        if team_id in team_form_cache:
+            return team_form_cache[team_id]
+
+        try:
+            response = requests.get(
+                "https://v3.football.api-sports.io/fixtures",
+                params={"team": team_id, "last": 5},
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            fixtures = payload.get("response", [])
+            summary = _summarize_team_form(team_id, fixtures)
+            team_form_cache[team_id] = summary
+            time.sleep(0.15)
+            return summary
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.warning("Failed to fetch team form", extra={"teamId": team_id, "error": str(exc)})
+            team_form_cache[team_id] = None
+            return None
+
+    def get_head_to_head(home_id: Optional[int], away_id: Optional[int]) -> Optional[Dict[str, object]]:
+        if not home_id or not away_id:
+            return None
+        key = (home_id, away_id)
+        if key in head_to_head_cache:
+            return head_to_head_cache[key]
+
+        try:
+            response = requests.get(
+                "https://v3.football.api-sports.io/fixtures/headtohead",
+                params={"h2h": f"{home_id}-{away_id}", "last": 5},
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            fixtures = payload.get("response", [])
+            summary = _summarize_head_to_head(home_id, away_id, fixtures)
+            head_to_head_cache[key] = summary
+            time.sleep(0.15)
+            return summary
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.warning(
+                "Failed to fetch head-to-head",
+                extra={"homeId": home_id, "awayId": away_id, "error": str(exc)},
+            )
+            head_to_head_cache[key] = None
+            return None
+
     for fixture in fixtures_to_process:
         competition = index.identify(fixture.get("league"))
         if not competition:
@@ -99,6 +349,13 @@ def fetch_matches(
             except ValueError:
                 time_str = date_str
 
+        home_team = fixture.get("teams", {}).get("home", {})
+        away_team = fixture.get("teams", {}).get("away", {})
+
+        home_form = get_team_form(home_team.get("id"))
+        away_form = get_team_form(away_team.get("id"))
+        head_to_head = get_head_to_head(home_team.get("id"), away_team.get("id"))
+
         match_entry = {
             "fixtureId": fixture_id,
             "date": date_str,
@@ -117,16 +374,21 @@ def fetch_matches(
             },
             "teams": {
                 "home": {
-                    "name": fixture.get("teams", {}).get("home", {}).get("name"),
-                    "logo": fixture.get("teams", {}).get("home", {}).get("logo"),
+                    "name": home_team.get("name"),
+                    "logo": home_team.get("logo"),
                 },
                 "away": {
-                    "name": fixture.get("teams", {}).get("away", {}).get("name"),
-                    "logo": fixture.get("teams", {}).get("away", {}).get("logo"),
+                    "name": away_team.get("name"),
+                    "logo": away_team.get("logo"),
                 },
             },
             "venue": fixture_info.get("venue", {}).get("name") or "TBD",
             "odds": odds_data,
+            "form": {
+                "home": home_form,
+                "away": away_form,
+                "headToHead": head_to_head,
+            },
         }
 
         matches.append(match_entry)

--- a/python_bot/message_builder.py
+++ b/python_bot/message_builder.py
@@ -61,6 +61,9 @@ def format_predictions_message(match_data: Dict[str, object], analysis: Dict[str
                         away=predictions.get("awayWinProbability", 0),
                     )
                 )
+            notes = match.get("analysisNotes") or []
+            if notes:
+                message_lines.append(f"📝 PK: {' • '.join(notes[:2])}")
             message_lines.append("")
     else:
         message_lines.append("😔 <b>Não há jogos com odds interessantes hoje.</b>")

--- a/src/mastra/tools/analyzeOddsAndMarkets.ts
+++ b/src/mastra/tools/analyzeOddsAndMarkets.ts
@@ -15,6 +15,98 @@ type AnalyzedMatch = any & {
   };
   confidence: "low" | "medium" | "high";
   recommendedBets: string[];
+  analysisNotes?: string[];
+};
+
+type TeamFormSummary = {
+  currentStreak?: { type?: string; count?: number } | null;
+  recentRecord?: string;
+  avgGoalsFor?: number;
+  avgGoalsAgainst?: number;
+  goalDifferenceAvg?: number;
+  winRate?: number;
+  drawRate?: number;
+  lossRate?: number;
+};
+
+type HeadToHeadSummary = {
+  homeWins?: number;
+  awayWins?: number;
+  draws?: number;
+  avgGoalsTotal?: number;
+} | null;
+
+const normalizeMarketValue = (value: unknown): string => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  return value
+    .toString()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[,]/g, ".")
+    .replace(/[()]/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+};
+
+const HOME_LABELS = new Set([
+  "home",
+  "1",
+  "home team",
+  "team 1",
+  "1 home",
+]);
+
+const DRAW_LABELS = new Set([
+  "draw",
+  "x",
+  "empate",
+]);
+
+const AWAY_LABELS = new Set([
+  "away",
+  "2",
+  "away team",
+  "team 2",
+  "2 away",
+]);
+
+const YES_LABELS = new Set([
+  "yes",
+  "sim",
+  "y",
+  "s",
+]);
+
+const NO_LABELS = new Set([
+  "no",
+  "nao",
+  "n",
+]);
+
+const isOver25Label = (value: unknown): boolean => {
+  const normalized = normalizeMarketValue(value);
+  if (!normalized) return false;
+
+  if (normalized.includes("over") || normalized.includes("mais de")) {
+    return normalized.includes("2.5") || normalized.includes("25");
+  }
+
+  return false;
+};
+
+const isUnder25Label = (value: unknown): boolean => {
+  const normalized = normalizeMarketValue(value);
+  if (!normalized) return false;
+
+  if (normalized.includes("under") || normalized.includes("menos de")) {
+    return normalized.includes("2.5") || normalized.includes("25");
+  }
+
+  return false;
 };
 
 const analyzeMatchOdds = ({
@@ -45,6 +137,7 @@ const analyzeMatchOdds = ({
       },
       recommendedBets: [] as string[],
       confidence: "low" as "low" | "medium" | "high",
+      analysisNotes: [] as string[],
     };
 
     if (!match.odds || match.odds.length === 0) {
@@ -62,9 +155,13 @@ const analyzeMatchOdds = ({
 
       // Convert odds to probabilities (probability = 1 / decimal_odds)
       if (matchWinnerBet && matchWinnerBet.values) {
-        const homeOdd = parseFloat(matchWinnerBet.values.find((v: any) => v.value === "Home")?.odd || "0");
-        const drawOdd = parseFloat(matchWinnerBet.values.find((v: any) => v.value === "Draw")?.odd || "0");
-        const awayOdd = parseFloat(matchWinnerBet.values.find((v: any) => v.value === "Away")?.odd || "0");
+        const homeEntry = matchWinnerBet.values.find((v: any) => HOME_LABELS.has(normalizeMarketValue(v.value)));
+        const drawEntry = matchWinnerBet.values.find((v: any) => DRAW_LABELS.has(normalizeMarketValue(v.value)));
+        const awayEntry = matchWinnerBet.values.find((v: any) => AWAY_LABELS.has(normalizeMarketValue(v.value)));
+
+        const homeOdd = parseFloat(homeEntry?.odd ?? "0");
+        const drawOdd = parseFloat(drawEntry?.odd ?? "0");
+        const awayOdd = parseFloat(awayEntry?.odd ?? "0");
 
         if (homeOdd > 0) analysis.predictions.homeWinProbability = Math.round((1 / homeOdd) * 100);
         if (drawOdd > 0) analysis.predictions.drawProbability = Math.round((1 / drawOdd) * 100);
@@ -79,8 +176,11 @@ const analyzeMatchOdds = ({
 
       // Over/Under 2.5 goals analysis
       if (overUnderBet && overUnderBet.values) {
-        const over25Odd = parseFloat(overUnderBet.values.find((v: any) => v.value === "Over 2.5")?.odd || "0");
-        const under25Odd = parseFloat(overUnderBet.values.find((v: any) => v.value === "Under 2.5")?.odd || "0");
+        const overEntry = overUnderBet.values.find((v: any) => isOver25Label(v.value));
+        const underEntry = overUnderBet.values.find((v: any) => isUnder25Label(v.value));
+
+        const over25Odd = parseFloat(overEntry?.odd ?? "0");
+        const under25Odd = parseFloat(underEntry?.odd ?? "0");
 
         if (over25Odd > 0) analysis.predictions.over25Probability = Math.round((1 / over25Odd) * 100);
         if (under25Odd > 0) analysis.predictions.under25Probability = Math.round((1 / under25Odd) * 100);
@@ -93,8 +193,11 @@ const analyzeMatchOdds = ({
 
       // Both Teams to Score (BTTS) analysis
       if (bttsBet && bttsBet.values) {
-        const bttsYesOdd = parseFloat(bttsBet.values.find((v: any) => v.value === "Yes")?.odd || "0");
-        const bttsNoOdd = parseFloat(bttsBet.values.find((v: any) => v.value === "No")?.odd || "0");
+        const yesEntry = bttsBet.values.find((v: any) => YES_LABELS.has(normalizeMarketValue(v.value)));
+        const noEntry = bttsBet.values.find((v: any) => NO_LABELS.has(normalizeMarketValue(v.value)));
+
+        const bttsYesOdd = parseFloat(yesEntry?.odd ?? "0");
+        const bttsNoOdd = parseFloat(noEntry?.odd ?? "0");
 
         if (bttsYesOdd > 0) analysis.predictions.bttsYesProbability = Math.round((1 / bttsYesOdd) * 100);
         if (bttsNoOdd > 0) analysis.predictions.bttsNoProbability = Math.round((1 / bttsNoOdd) * 100);
@@ -147,8 +250,86 @@ const analyzeMatchOdds = ({
         totalConfidence += 1;
       }
 
+      const notes: string[] = [];
+      let qualitativeBoost = 0;
+
+      const homeForm = (match.form?.home ?? null) as TeamFormSummary | null;
+      const awayForm = (match.form?.away ?? null) as TeamFormSummary | null;
+      const headToHead = (match.form?.headToHead ?? null) as HeadToHeadSummary;
+
+      const summarizeRecord = (record?: string) => (record ?? "").slice(0, 5);
+
+      if (homeForm?.currentStreak?.type === "win" && (homeForm.currentStreak.count ?? 0) >= 3) {
+        notes.push(
+          `Casa com ${homeForm.currentStreak.count} vitórias seguidas (${summarizeRecord(homeForm.recentRecord)})`,
+        );
+        qualitativeBoost += 1;
+      }
+
+      if (awayForm?.currentStreak?.type === "loss" && (awayForm.currentStreak.count ?? 0) >= 2) {
+        notes.push(
+          `Visitante sem vencer há ${awayForm.currentStreak.count} jogos (${summarizeRecord(awayForm.recentRecord)})`,
+        );
+        qualitativeBoost += 1;
+      }
+
+      const avgAttack = (homeForm?.avgGoalsFor ?? 0) + (awayForm?.avgGoalsFor ?? 0);
+      if (avgAttack >= 3.2) {
+        notes.push("Tendência de muitos golos (médias ofensivas altas nas últimas partidas)");
+      } else if (avgAttack <= 2.0) {
+        notes.push("Tendência de poucos golos nos últimos jogos das equipas");
+      }
+
+      if ((headToHead?.homeWins ?? 0) >= 3) {
+        notes.push("Histórico recente favorável ao mandante no confronto direto");
+        qualitativeBoost += 1;
+      }
+
+      if ((headToHead?.avgGoalsTotal ?? 0) >= 3) {
+        notes.push("Confrontos diretos recentes com média superior a 3 golos");
+      }
+
+      analysis.analysisNotes = notes.slice(0, 3);
+
+      const formCount = (homeForm ? 1 : 0) + (awayForm ? 1 : 0) || 1;
+      const drawRate = ((homeForm?.drawRate ?? 0) + (awayForm?.drawRate ?? 0)) / formCount;
+      const shouldBackfillProbabilities =
+        analysis.predictions.homeWinProbability === 0 &&
+        analysis.predictions.awayWinProbability === 0 &&
+        analysis.predictions.drawProbability === 0 &&
+        (homeForm || awayForm);
+
+      if (shouldBackfillProbabilities) {
+        const drawProbability = Math.round(Math.min(drawRate, 0.45) * 100);
+        const homeScore =
+          (homeForm?.winRate ?? 0) +
+          Math.max(homeForm?.goalDifferenceAvg ?? 0, 0) +
+          (awayForm?.lossRate ?? 0) * 0.6;
+        const awayScore =
+          (awayForm?.winRate ?? 0) +
+          Math.max(awayForm?.goalDifferenceAvg ?? 0, 0) +
+          (homeForm?.lossRate ?? 0) * 0.6;
+
+        const total = homeScore + awayScore;
+        const available = Math.max(0, 100 - drawProbability);
+
+        if (total > 0) {
+          analysis.predictions.homeWinProbability = Math.round((homeScore / total) * available);
+          analysis.predictions.awayWinProbability = Math.max(
+            0,
+            available - analysis.predictions.homeWinProbability,
+          );
+        } else {
+          analysis.predictions.homeWinProbability = Math.round(available / 2);
+          analysis.predictions.awayWinProbability = available - analysis.predictions.homeWinProbability;
+        }
+
+        analysis.predictions.drawProbability = drawProbability;
+      }
+
+      totalConfidence += qualitativeBoost;
       analysis.recommendedBets = recommendations;
-      
+
       // Determine overall confidence
       if (totalConfidence >= 5) {
         analysis.confidence = "high";

--- a/src/mastra/workflows/footballPredictionsWorkflow.ts
+++ b/src/mastra/workflows/footballPredictionsWorkflow.ts
@@ -187,6 +187,9 @@ const sendPredictionsStep = createStep({
         if (match.predictions) {
           message += `📈 Prob: Casa ${match.predictions.homeWinProbability}% | Empate ${match.predictions.drawProbability}% | Fora ${match.predictions.awayWinProbability}%\n`;
         }
+        if (match.analysisNotes && match.analysisNotes.length > 0) {
+          message += `📝 PK: ${match.analysisNotes.slice(0, 2).join(' • ')}\n`;
+        }
         message += `\n`;
       });
     }
@@ -222,6 +225,9 @@ const sendPredictionsStep = createStep({
               if (predictions.bttsYesProbability > 0 || predictions.bttsNoProbability > 0) {
                 message += `🥅 BTTS: Sim ${predictions.bttsYesProbability}% | Não ${predictions.bttsNoProbability}%\n`;
               }
+            }
+            if (match.analysisNotes && match.analysisNotes.length > 0) {
+              message += `📝 PK: ${match.analysisNotes.slice(0, 2).join(' • ')}\n`;
             }
 
             message += `\n`;


### PR DESCRIPTION
## Summary
- fetch last matches and head-to-head data to enrich each fixture with form summaries, cached to respect API limits
- derive fallback probabilities and analysis notes from recent form in both bots and Mastra tooling, and surface the new "PK" highlights in outgoing messages
- document form-based analysis improvements and add instructions to pause/resume cron or PM2 jobs in the README

## Testing
- python -m compileall python_bot
- npm run check *(fails: repo lacks Mastra/TypeScript dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e63070b5708325b20232c658e110f1