### PR TITLE
Integrate Forebet probabilities and expand odds normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Este repositório contém duas portas independentes (Python e Node.js) do fluxo 
 | `TELEGRAM_CHANNEL_ID` | ⚪️ | Canal público (ex.: `@meucanal`) caso queira publicar automaticamente. |
 | `FOOTBALL_API_BOOKMAKER` | ⚪️ | ID do bookmaker desejado (padrão `6` – Pinnacle). |
 | `FOOTBALL_MAX_FIXTURES` | ⚪️ | Limite de jogos carregados por execução (padrão `120`). |
+| `TELEGRAM_OWNER_ID` | ⚪️ | ID numérico da conta que poderá usar o comando exclusivo `/insight`. |
+| `OPENAI_API_KEY` | ⚪️ | Chave da OpenAI para gerar resumos via ChatGPT (opcional). |
+| `OPENAI_MODEL` | ⚪️ | Modelo da OpenAI a utilizar (padrão `gpt-4o-mini`). |
 
 ### Guardando os segredos com segurança
 
@@ -81,6 +84,26 @@ FOOTBALL_MAX_FIXTURES=120
 
 > Ambas as versões aceitam `--date YYYY-MM-DD` para backfill e `--output arquivo.json` para salvar o payload completo.
 
+### Comando privado com ChatGPT (owner)
+
+Quando quiser pedir uma análise sob demanda directamente pelo Telegram:
+
+1. Defina no `.env`:
+   ```env
+   TELEGRAM_OWNER_ID=123456789
+   OPENAI_API_KEY=sk-...
+   ```
+   (o `OPENAI_API_KEY` é opcional; sem ele, o resumo GPT não será anexado).
+2. Inicie o listener dedicado:
+   ```bash
+   python -m python_bot.owner_command --env .env
+   ```
+3. No chat privado com o bot, envie comandos como:
+   * `/insight city` → procura o próximo jogo do Manchester City e gera análise completa.
+   * `/insight city-psg` → foca no confronto directo entre City e PSG.
+
+O bot devolve as probabilidades calculadas, recomendações do modelo, notas PK e, se configurado, um resumo em linguagem natural vindo do ChatGPT. Apenas o `TELEGRAM_OWNER_ID` configurado pode usar este comando; pedidos de outros utilizadores são recusados automaticamente.
+
 ---
 
 ## 3. Deixando online 24/7 na sua máquina
@@ -122,6 +145,9 @@ Lembre-se: se o computador for desligado, o bot para. Para ficar online 24/7 use
 ## 5. Como a análise funciona
 
 * **Conversão de odds em probabilidade:** cada odd decimal é convertida em percentual (`100 / odd`).
+* **Sinais externos (Forebet):** quando a API não devolve odds ou mercados completos, o bot tenta capturar as probabilidades 1X2/Over 2.5/BTTS disponibilizadas publicamente pela Forebet para preencher os buracos sem deixar valores zerados.
+* **Form vs. histórico:** quando uma casa de apostas não oferece odds para 1X2, usamos o desempenho recente (últimos 5 jogos) e o confronto direto para estimar probabilidades, evitando relatórios zerados.
+* **Notas chave (PK):** para cada destaque são listados até 2 “pontos-chave” baseados na forma das equipas (sequência de vitórias/derrotas, média de golos, confrontos diretos).
 * **Classificação de confiança:** partidas com probabilidades altas geram recomendações "Forte favorito" ou "Favorito". Mercados Over/Under e Ambos Marcam entram na lista caso ultrapassem 60%.
 * **Pontuação e ordenação:** os jogos são reordenados por confiança e quantidade de recomendações, exibindo os melhores primeiro e organizando por região/competição.
 * **Resumo agregado:** o relatório mostra quantos jogos de alta ou média confiança existem por região, ajudando a priorizar ligas.
@@ -139,5 +165,44 @@ Para ver a lógica exata consulte:
 * Ajuste a lista de competições em `shared/competitions.json` para focar apenas nos campeonatos desejados.
 * Ajuste os thresholds de confiança no `analyzer.py` caso queira alertas mais conservadores ou agressivos.
 * Integre com outras saídas (Discord, e-mail) reutilizando a função `message_builder.build_message`.
+
+---
+
+## 7. Gerindo jobs agendados (cron/PM2)
+
+Quando precisar parar o bot para aplicar atualizações ou trocar credenciais, basta seguir os passos abaixo conforme a ferramenta usada:
+
+### Cron (Linux/macOS)
+
+1. **Listar o agendamento atual:**
+   ```bash
+   crontab -l
+   ```
+2. **Editar/pausar temporariamente:** comente a linha do bot adicionando `#` no início.
+   ```bash
+   crontab -e
+   # 0 9 * * * /caminho/para/.venv/bin/python -m python_bot.main --env /caminho/.env
+   ```
+3. **Aplicar a atualização (pull/commit/etc.)**
+4. **Reativar:** remova o `#` e salve novamente com `crontab -e`.
+
+### PM2 (Node.js)
+
+```bash
+# Parar o processo
+npx pm2 stop futebol-bot
+
+# Aplicar atualizações no código
+git pull
+npm install
+
+# Subir novamente (ajuste o comando conforme seu fluxo)
+npx pm2 start "node js_bot/index.js --env /caminho/.env" --name futebol-bot --cron "0 9 * * *"
+
+# Verificar status
+npx pm2 status futebol-bot
+```
+
+Para remover definitivamente um job agendado, use `crontab -e` (removendo a linha) ou `npx pm2 delete futebol-bot`. Depois de reinstalar dependências ou atualizar o código, execute os comandos de start novamente.
 
 Com esse guia você consegue hospedar o bot no seu PC, VPS ou Replit, mantendo as credenciais seguras e garantindo execuções automáticas confiáveis.

--- a/js_bot/index.js
+++ b/js_bot/index.js
@@ -77,6 +77,126 @@ function identifyCompetition(league) {
   return null;
 }
 
+function decodeHtml(text) {
+  if (!text) return '';
+  return text
+    .replace(/<br\s*\/?\s*>/gi, ' ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .trim();
+}
+
+function buildForebetKey(home, away) {
+  const homeKey = normalize(home);
+  const awayKey = normalize(away);
+  if (!homeKey || !awayKey) return null;
+  return `${homeKey}|${awayKey}`;
+}
+
+function parsePercentages(text) {
+  if (!text) return [];
+  const matches = [...text.matchAll(/(-?\d+(?:\.\d+)?)\s*%/g)];
+  return matches.map((match) => Number(match[1]));
+}
+
+function parseForebetHtml(html, logger) {
+  const results = new Map();
+  if (!html) return results;
+
+  const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+  let rowMatch;
+  while ((rowMatch = rowRegex.exec(html)) !== null) {
+    const rowHtml = rowMatch[1];
+    const cellRegex = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+    const cells = [];
+    let cellMatch;
+    while ((cellMatch = cellRegex.exec(rowHtml)) !== null) {
+      cells.push(decodeHtml(cellMatch[1]));
+    }
+
+    if (cells.length < 3) continue;
+
+    let homeTeam = null;
+    let awayTeam = null;
+
+    const homeMatch = rowHtml.match(/class="[^"]*(home|tnms|team1)[^"]*"[^>]*>([\s\S]*?)<\/td>/i);
+    const awayMatch = rowHtml.match(/class="[^"]*(away|tnms2|team2)[^"]*"[^>]*>([\s\S]*?)<\/td>/i);
+
+    if (homeMatch) homeTeam = decodeHtml(homeMatch[2]);
+    if (awayMatch) awayTeam = decodeHtml(awayMatch[2]);
+
+    if (!homeTeam || !awayTeam) {
+      homeTeam = homeTeam || cells[1];
+      awayTeam = awayTeam || cells[2];
+    }
+
+    if (!homeTeam || !awayTeam) continue;
+
+    const percentages = cells.flatMap((cell) => parsePercentages(cell));
+    if (percentages.length < 3) continue;
+
+    const key = buildForebetKey(homeTeam, awayTeam);
+    if (!key || results.has(key)) continue;
+
+    const [homeProb, drawProb, awayProb] = percentages;
+    const overProb = percentages[3];
+    const underProb = percentages[4];
+    const bttsYes = percentages[5];
+    const bttsNo = percentages[6];
+
+    results.set(key, {
+      source: 'Forebet',
+      homeWinProbability: Math.round(homeProb ?? 0),
+      drawProbability: Math.round(drawProb ?? 0),
+      awayWinProbability: Math.round(awayProb ?? 0),
+      over25Probability: overProb !== undefined ? Math.round(overProb) : undefined,
+      under25Probability: underProb !== undefined ? Math.round(underProb) : undefined,
+      bttsYesProbability: bttsYes !== undefined ? Math.round(bttsYes) : undefined,
+      bttsNoProbability: bttsNo !== undefined ? Math.round(bttsNo) : undefined,
+    });
+  }
+
+  logger?.info?.(`Loaded ${results.size} Forebet predictions`);
+  return results;
+}
+
+async function fetchForebetPredictions(date, logger) {
+  try {
+    const targetDate = new Date(`${date}T00:00:00Z`);
+    const today = new Date();
+    const isToday =
+      targetDate.getUTCFullYear() === today.getUTCFullYear() &&
+      targetDate.getUTCMonth() === today.getUTCMonth() &&
+      targetDate.getUTCDate() === today.getUTCDate();
+    const slug = isToday ? 'today' : date;
+    const url = `https://www.forebet.com/en/football-tips-and-predictions-for-${slug}`;
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+    });
+
+    if (!response.ok) {
+      logger?.warn?.(`Forebet request failed: ${response.status}`);
+      return new Map();
+    }
+
+    const html = await response.text();
+    return parseForebetHtml(html, logger);
+  } catch (error) {
+    logger?.warn?.(`Unable to load Forebet predictions: ${error.message}`);
+    return new Map();
+  }
+}
+
 async function fetchJson(url, params, headers, timeout = 30000) {
   const urlObj = new URL(url);
   if (params) {
@@ -94,6 +214,218 @@ async function fetchJson(url, params, headers, timeout = 30000) {
     throw new Error(`Request failed: ${response.status} ${response.statusText}`);
   }
   return response.json();
+}
+
+function extractScore(fixture) {
+  const goals = fixture.goals ?? {};
+  const score = fixture.score ?? {};
+  const fullTime = score.fulltime ?? {};
+  const extra = score.extratime ?? {};
+  const penalties = score.penalty ?? {};
+
+  const homeGoals = goals.home ?? fullTime.home ?? extra.home ?? penalties.home ?? 0;
+  const awayGoals = goals.away ?? fullTime.away ?? extra.away ?? penalties.away ?? 0;
+
+  return { homeGoals: Number(homeGoals) || 0, awayGoals: Number(awayGoals) || 0 };
+}
+
+function summarizeTeamFixtures(teamId, fixtures = []) {
+  if (!teamId || !Array.isArray(fixtures) || fixtures.length === 0) {
+    return null;
+  }
+
+  const ordered = [...fixtures].sort((a, b) => (b.fixture?.timestamp || 0) - (a.fixture?.timestamp || 0));
+  const matches = [];
+  let wins = 0;
+  let draws = 0;
+  let losses = 0;
+  let goalsFor = 0;
+  let goalsAgainst = 0;
+  let cleanSheets = 0;
+  let failedToScore = 0;
+
+  for (const fixture of ordered) {
+    const { homeGoals, awayGoals } = extractScore(fixture);
+    const isHome = fixture.teams?.home?.id === teamId;
+    const opponent = isHome ? fixture.teams?.away : fixture.teams?.home;
+    const goalsForMatch = isHome ? homeGoals : awayGoals;
+    const goalsAgainstMatch = isHome ? awayGoals : homeGoals;
+
+    let winner = null;
+    if (fixture.teams?.home?.winner === true && fixture.teams?.away?.winner === false) {
+      winner = 'home';
+    } else if (fixture.teams?.home?.winner === false && fixture.teams?.away?.winner === true) {
+      winner = 'away';
+    } else if (homeGoals > awayGoals) {
+      winner = 'home';
+    } else if (awayGoals > homeGoals) {
+      winner = 'away';
+    } else {
+      winner = 'draw';
+    }
+
+    const resultCode =
+      winner === 'draw' ? 'E' : winner === (isHome ? 'home' : 'away') ? 'V' : 'D';
+
+    matches.push({
+      fixtureId: fixture.fixture?.id,
+      date: fixture.fixture?.date,
+      opponent: opponent?.name,
+      competition: fixture.league?.name,
+      score: `${homeGoals}-${awayGoals}`,
+      result: resultCode,
+    });
+
+    goalsFor += goalsForMatch;
+    goalsAgainst += goalsAgainstMatch;
+
+    if (resultCode === 'V') wins += 1;
+    else if (resultCode === 'E') draws += 1;
+    else losses += 1;
+
+    if (goalsAgainstMatch === 0) cleanSheets += 1;
+    if (goalsForMatch === 0) failedToScore += 1;
+  }
+
+  const total = matches.length;
+  if (total === 0) return null;
+
+  const recentRecord = matches.map((match) => match.result).join('');
+  const firstResult = matches[0]?.result ?? 'E';
+  let streakCount = 0;
+  for (const match of matches) {
+    if (match.result === firstResult) streakCount += 1;
+    else break;
+  }
+
+  const streakType =
+    firstResult === 'V' ? 'win' : firstResult === 'D' ? 'loss' : firstResult === 'E' ? 'draw' : 'unknown';
+
+  const avgGoalsFor = Number((goalsFor / total).toFixed(2));
+  const avgGoalsAgainst = Number((goalsAgainst / total).toFixed(2));
+
+  return {
+    sampleSize: total,
+    matches,
+    wins,
+    draws,
+    losses,
+    winRate: total ? wins / total : 0,
+    drawRate: total ? draws / total : 0,
+    lossRate: total ? losses / total : 0,
+    formPoints: wins * 3 + draws,
+    avgGoalsFor,
+    avgGoalsAgainst,
+    avgGoalsTotal: Number(((goalsFor + goalsAgainst) / total).toFixed(2)),
+    goalDifferenceAvg: Number((avgGoalsFor - avgGoalsAgainst).toFixed(2)),
+    cleanSheets,
+    failedToScore,
+    recentRecord,
+    currentStreak: { type: streakType, count: streakCount },
+  };
+}
+
+function summarizeHeadToHead(homeId, awayId, fixtures = []) {
+  if (!homeId || !awayId || fixtures.length === 0) {
+    return null;
+  }
+
+  const ordered = [...fixtures].sort((a, b) => (b.fixture?.timestamp || 0) - (a.fixture?.timestamp || 0));
+  const matches = [];
+  let homeWins = 0;
+  let awayWins = 0;
+  let draws = 0;
+  let totalGoals = 0;
+
+  for (const fixture of ordered) {
+    const { homeGoals, awayGoals } = extractScore(fixture);
+    const fixtureHomeId = fixture.teams?.home?.id;
+    const fixtureAwayId = fixture.teams?.away?.id;
+    const upcomingHomeWasHome = fixtureHomeId === homeId;
+
+    let result = 'E';
+    if (homeGoals !== awayGoals) {
+      const didHomeWin = fixture.teams?.home?.winner ?? homeGoals > awayGoals;
+      const upcomingHomeWon = upcomingHomeWasHome ? didHomeWin : !(didHomeWin);
+      if (upcomingHomeWon) {
+        result = 'V';
+        homeWins += 1;
+      } else {
+        result = 'D';
+        awayWins += 1;
+      }
+    } else {
+      draws += 1;
+    }
+
+    matches.push({
+      fixtureId: fixture.fixture?.id,
+      date: fixture.fixture?.date,
+      venue: fixture.fixture?.venue?.name,
+      score: `${homeGoals}-${awayGoals}`,
+      result,
+    });
+
+    totalGoals += homeGoals + awayGoals;
+  }
+
+  const sampleSize = matches.length;
+  if (sampleSize === 0) return null;
+
+  return {
+    sampleSize,
+    matches,
+    homeWins,
+    awayWins,
+    draws,
+    avgGoalsTotal: Number((totalGoals / sampleSize).toFixed(2)),
+  };
+}
+
+const teamFormCache = new Map();
+const headToHeadCache = new Map();
+
+async function fetchTeamForm(teamId, headers, logger) {
+  if (!teamId) return null;
+  if (teamFormCache.has(teamId)) return teamFormCache.get(teamId);
+
+  try {
+    const payload = await fetchJson(
+      'https://v3.football.api-sports.io/fixtures',
+      { team: teamId, last: 5 },
+      headers,
+    );
+    const fixtures = payload.response || [];
+    const summary = summarizeTeamFixtures(teamId, fixtures);
+    teamFormCache.set(teamId, summary);
+    return summary;
+  } catch (error) {
+    logger.warn(`Failed to fetch form for team ${teamId}: ${error.message}`);
+    teamFormCache.set(teamId, null);
+    return null;
+  }
+}
+
+async function fetchHeadToHead(homeId, awayId, headers, logger) {
+  if (!homeId || !awayId) return null;
+  const key = `${homeId}-${awayId}`;
+  if (headToHeadCache.has(key)) return headToHeadCache.get(key);
+
+  try {
+    const payload = await fetchJson(
+      'https://v3.football.api-sports.io/fixtures/headtohead',
+      { h2h: `${homeId}-${awayId}`, last: 5 },
+      headers,
+    );
+    const fixtures = payload.response || [];
+    const summary = summarizeHeadToHead(homeId, awayId, fixtures);
+    headToHeadCache.set(key, summary);
+    return summary;
+  } catch (error) {
+    logger.warn(`Failed to fetch head-to-head for ${homeId}-${awayId}: ${error.message}`);
+    headToHeadCache.set(key, null);
+    return null;
+  }
 }
 
 async function fetchMatches(date, settings, logger) {
@@ -117,6 +449,7 @@ async function fetchMatches(date, settings, logger) {
 
   const matches = [];
   const regionCounters = Object.fromEntries(competitionData.regionOrder.map((region) => [region, 0]));
+  const forebetPredictions = await fetchForebetPredictions(date, logger);
 
   for (const fixture of fixturesToProcess) {
     const competition = identifyCompetition(fixture.league);
@@ -129,13 +462,43 @@ async function fetchMatches(date, settings, logger) {
     try {
       const oddsPayload = await fetchJson(
         'https://v3.football.api-sports.io/odds',
-        { fixture: fixtureId, bookmaker: settings.bookmakerId },
+        { fixture: fixtureId },
         headers,
       );
-      odds = oddsPayload.response?.[0]?.bookmakers?.[0]?.bets ?? [];
+
+      const bookmakers = oddsPayload.response?.[0]?.bookmakers ?? [];
+      const preferred = settings.bookmakerId;
+      const orderedBookmakers = [
+        ...bookmakers.filter((bookmaker) => bookmaker.id === preferred),
+        ...bookmakers.filter((bookmaker) => bookmaker.id !== preferred),
+      ];
+
+      const markets = new Map();
+      for (const bookmaker of orderedBookmakers) {
+        for (const bet of bookmaker.bets ?? []) {
+          if (!bet?.name) continue;
+          if (!markets.has(bet.name) || !(markets.get(bet.name)?.length > 0)) {
+            markets.set(bet.name, bet.values ?? []);
+          }
+        }
+      }
+
+      odds = Array.from(markets.entries()).map(([name, values]) => ({ name, values }));
     } catch (error) {
       logger.warn(`Failed to fetch odds for fixture ${fixtureId}: ${error.message}`);
     }
+
+    const homeTeamId = fixture.teams?.home?.id;
+    const awayTeamId = fixture.teams?.away?.id;
+
+    const [homeForm, awayForm, headToHead] = await Promise.all([
+      fetchTeamForm(homeTeamId, headers, logger),
+      fetchTeamForm(awayTeamId, headers, logger),
+      fetchHeadToHead(homeTeamId, awayTeamId, headers, logger),
+    ]);
+
+    const forebetKey = buildForebetKey(fixture.teams?.home?.name, fixture.teams?.away?.name);
+    const forebet = forebetKey ? forebetPredictions.get(forebetKey) ?? null : null;
 
     let time = '';
     if (fixture.fixture?.date) {
@@ -164,6 +527,12 @@ async function fetchMatches(date, settings, logger) {
       teams: fixture.teams,
       venue: fixture.fixture?.venue?.name ?? 'TBD',
       odds,
+      forebet,
+      form: {
+        home: homeForm,
+        away: awayForm,
+        headToHead,
+      },
     });
 
     regionCounters[competition.region] = (regionCounters[competition.region] || 0) + 1;
@@ -185,6 +554,67 @@ async function fetchMatches(date, settings, logger) {
       })),
     },
   };
+}
+
+function normalizeMarketValue(value) {
+  if (value === undefined || value === null) return '';
+  return value
+    .toString()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[,]/g, '.')
+    .replace(/[()]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+}
+
+const HOME_LABELS = new Set(['home', '1', 'home team', 'team 1', '1 home']);
+const DRAW_LABELS = new Set(['draw', 'x', 'empate']);
+const AWAY_LABELS = new Set(['away', '2', 'away team', 'team 2', '2 away']);
+const YES_LABELS = new Set(['yes', 'sim', 'y', 's']);
+const NO_LABELS = new Set(['no', 'nao', 'n']);
+
+const MARKET_ALIASES = new Map([
+  [
+    'match_winner',
+    new Set(['match winner', '1x2', 'full time result', 'match result', 'result', 'win-draw-win']),
+  ],
+  [
+    'goals_over_under',
+    new Set(['goals over/under', 'over/under', 'goals', 'goals o/u', 'total goals']),
+  ],
+  [
+    'both_teams_score',
+    new Set(['both teams score', 'both teams to score', 'btts', 'gg/ng', 'goal goal']),
+  ],
+]);
+
+function normalizeMarketName(value) {
+  const normalized = normalizeMarketValue(value);
+  if (!normalized) return '';
+  for (const [key, aliases] of MARKET_ALIASES.entries()) {
+    if (aliases.has(normalized)) return key;
+  }
+  return normalized;
+}
+
+function isOver25Label(value) {
+  const normalized = normalizeMarketValue(value);
+  if (!normalized) return false;
+  if (normalized.includes('over') || normalized.includes('mais de')) {
+    return normalized.includes('2.5') || normalized.includes('25');
+  }
+  return false;
+}
+
+function isUnder25Label(value) {
+  const normalized = normalizeMarketValue(value);
+  if (!normalized) return false;
+  if (normalized.includes('under') || normalized.includes('menos de')) {
+    return normalized.includes('2.5') || normalized.includes('25');
+  }
+  return false;
 }
 
 function probabilityFromOdd(odd) {
@@ -209,27 +639,57 @@ function analyzeMatches(matches, logger) {
       },
       recommendedBets: [],
       confidence: 'low',
+      analysisNotes: [],
     };
 
     const markets = new Map();
+    const forebet = match.forebet || null;
+    let forebetUsed = false;
     for (const market of match.odds || []) {
-      markets.set(market.name, market.values || []);
+      const key = normalizeMarketName(market?.name);
+      if (!key) continue;
+      const values = Array.isArray(market?.values) ? market.values : [];
+      if (!markets.has(key) || !(markets.get(key)?.length > 0)) {
+        markets.set(key, values);
+      }
     }
 
-    for (const value of markets.get('Match Winner') || []) {
-      if (value.value === 'Home') entry.predictions.homeWinProbability = probabilityFromOdd(value.odd);
-      if (value.value === 'Draw') entry.predictions.drawProbability = probabilityFromOdd(value.odd);
-      if (value.value === 'Away') entry.predictions.awayWinProbability = probabilityFromOdd(value.odd);
+    for (const value of markets.get('match_winner') || []) {
+      const normalized = normalizeMarketValue(value.value);
+      if (HOME_LABELS.has(normalized)) entry.predictions.homeWinProbability = probabilityFromOdd(value.odd);
+      if (DRAW_LABELS.has(normalized)) entry.predictions.drawProbability = probabilityFromOdd(value.odd);
+      if (AWAY_LABELS.has(normalized)) entry.predictions.awayWinProbability = probabilityFromOdd(value.odd);
     }
 
-    for (const value of markets.get('Goals Over/Under') || []) {
-      if (value.value === 'Over 2.5') entry.predictions.over25Probability = probabilityFromOdd(value.odd);
-      if (value.value === 'Under 2.5') entry.predictions.under25Probability = probabilityFromOdd(value.odd);
+    for (const value of markets.get('goals_over_under') || []) {
+      if (isOver25Label(value.value)) entry.predictions.over25Probability = probabilityFromOdd(value.odd);
+      if (isUnder25Label(value.value)) entry.predictions.under25Probability = probabilityFromOdd(value.odd);
     }
 
-    for (const value of markets.get('Both Teams Score') || []) {
-      if (value.value === 'Yes') entry.predictions.bttsYesProbability = probabilityFromOdd(value.odd);
-      if (value.value === 'No') entry.predictions.bttsNoProbability = probabilityFromOdd(value.odd);
+    for (const value of markets.get('both_teams_score') || []) {
+      const normalized = normalizeMarketValue(value.value);
+      if (YES_LABELS.has(normalized)) entry.predictions.bttsYesProbability = probabilityFromOdd(value.odd);
+      if (NO_LABELS.has(normalized)) entry.predictions.bttsNoProbability = probabilityFromOdd(value.odd);
+    }
+
+    if (forebet) {
+      const applyForebet = (sourceKey, targetKey) => {
+        if (entry.predictions[targetKey]) return;
+        const raw = forebet[sourceKey];
+        const value = Number(raw);
+        if (Number.isFinite(value) && value > 0) {
+          entry.predictions[targetKey] = Math.max(0, Math.min(100, Math.round(value)));
+          forebetUsed = true;
+        }
+      };
+
+      applyForebet('homeWinProbability', 'homeWinProbability');
+      applyForebet('drawProbability', 'drawProbability');
+      applyForebet('awayWinProbability', 'awayWinProbability');
+      applyForebet('over25Probability', 'over25Probability');
+      applyForebet('under25Probability', 'under25Probability');
+      applyForebet('bttsYesProbability', 'bttsYesProbability');
+      applyForebet('bttsNoProbability', 'bttsNoProbability');
     }
 
     const recommendations = [];
@@ -272,6 +732,76 @@ function analyzeMatches(matches, logger) {
       confidenceScore += 1;
     }
 
+    const notes = [];
+    let qualitativeBoost = 0;
+    const homeForm = match.form?.home;
+    const awayForm = match.form?.away;
+    const headToHead = match.form?.headToHead;
+
+    if (homeForm?.currentStreak?.type === 'win' && homeForm.currentStreak.count >= 3) {
+      notes.push(
+        `Casa com ${homeForm.currentStreak.count} vitórias seguidas (${homeForm.recentRecord.slice(0, 5)})`,
+      );
+      qualitativeBoost += 1;
+    }
+
+    if (awayForm?.currentStreak?.type === 'loss' && awayForm.currentStreak.count >= 2) {
+      notes.push(`Visitante sem vencer há ${awayForm.currentStreak.count} jogos (${awayForm.recentRecord.slice(0, 5)})`);
+      qualitativeBoost += 1;
+    }
+
+    if ((homeForm?.avgGoalsFor ?? 0) + (awayForm?.avgGoalsFor ?? 0) >= 3.2) {
+      notes.push('Tendência de muitos golos (médias ofensivas altas nas últimas partidas)');
+    } else if ((homeForm?.avgGoalsFor ?? 0) + (awayForm?.avgGoalsFor ?? 0) <= 2.0) {
+      notes.push('Tendência de poucos golos nos últimos jogos das equipas');
+    }
+
+    if (headToHead?.homeWins && headToHead.homeWins >= 3) {
+      notes.push('Histórico recente favorável ao mandante no confronto direto');
+      qualitativeBoost += 1;
+    }
+
+    if (headToHead?.avgGoalsTotal && headToHead.avgGoalsTotal >= 3) {
+      notes.push('Confrontos diretos recentes com média superior a 3 golos');
+    }
+
+    if (forebetUsed) {
+      notes.push('Probabilidades 1X2 complementadas com dados da Forebet');
+    }
+
+    entry.analysisNotes = notes.slice(0, 3);
+
+    confidenceScore += qualitativeBoost;
+
+    if (
+      entry.predictions.homeWinProbability === 0 &&
+      entry.predictions.awayWinProbability === 0 &&
+      entry.predictions.drawProbability === 0 &&
+      (homeForm || awayForm)
+    ) {
+      const formCount = (homeForm ? 1 : 0) + (awayForm ? 1 : 0) || 1;
+      const drawRate = ((homeForm?.drawRate ?? 0) + (awayForm?.drawRate ?? 0)) / formCount;
+      const drawProbability = Math.round(Math.min(drawRate, 0.45) * 100);
+      const homeScore =
+        (homeForm?.winRate ?? 0) + (awayForm ? awayForm.lossRate * 0.6 : 0) + Math.max(homeForm?.goalDifferenceAvg ?? 0, 0);
+      const awayScore =
+        (awayForm?.winRate ?? 0) + (homeForm ? homeForm.lossRate * 0.6 : 0) + Math.max(awayForm?.goalDifferenceAvg ?? 0, 0);
+      const total = homeScore + awayScore;
+      const available = Math.max(0, 100 - drawProbability);
+      if (total > 0) {
+        entry.predictions.homeWinProbability = Math.round((homeScore / total) * available);
+        entry.predictions.awayWinProbability = Math.max(
+          0,
+          available - entry.predictions.homeWinProbability,
+        );
+        entry.predictions.drawProbability = drawProbability;
+      } else {
+        entry.predictions.homeWinProbability = Math.round(available / 2);
+        entry.predictions.awayWinProbability = available - entry.predictions.homeWinProbability;
+        entry.predictions.drawProbability = drawProbability;
+      }
+    }
+
     entry.recommendedBets = recommendations;
     if (confidenceScore >= 5) entry.confidence = 'high';
     else if (confidenceScore >= 3) entry.confidence = 'medium';
@@ -280,7 +810,13 @@ function analyzeMatches(matches, logger) {
 
   const score = (match) => {
     const base = { high: 3, medium: 2, low: 1 }[match.confidence] || 0;
-    return base * 10 + (match.recommendedBets?.length || 0);
+    const predictions = match.predictions || {};
+    const maxProbability = Math.max(
+      Number(predictions.homeWinProbability) || 0,
+      Number(predictions.drawProbability) || 0,
+      Number(predictions.awayWinProbability) || 0,
+    );
+    return base * 1000 + (match.recommendedBets?.length || 0) * 10 + maxProbability;
   };
 
   const sorted = [...analyzed].sort((a, b) => score(b) - score(a));
@@ -370,6 +906,9 @@ function buildMessage(matchData, analysis) {
       lines.push(
         `📈 Prob: Casa ${predictions.homeWinProbability}% | Empate ${predictions.drawProbability}% | Fora ${predictions.awayWinProbability}%`,
       );
+      if (match.analysisNotes?.length) {
+        lines.push(`📝 PK: ${match.analysisNotes.slice(0, 2).join(' • ')}`);
+      }
       lines.push('');
     }
   } else {

--- a/python_bot/analyzer.py
+++ b/python_bot/analyzer.py
@@ -1,9 +1,83 @@
 from __future__ import annotations
 
 import logging
+import re
+import unicodedata
 from typing import Dict, List, Optional
 
 from .competitions import CompetitionIndex
+
+
+HOME_LABELS = {"home", "1", "home team", "team 1", "1 home"}
+DRAW_LABELS = {"draw", "x", "empate"}
+AWAY_LABELS = {"away", "2", "away team", "team 2", "2 away"}
+YES_LABELS = {"yes", "sim", "y", "s"}
+NO_LABELS = {"no", "nao", "n"}
+
+MARKET_ALIASES = {
+    "match_winner": {
+        "match winner",
+        "1x2",
+        "full time result",
+        "match result",
+        "result",
+        "win-draw-win",
+    },
+    "goals_over_under": {
+        "goals over/under",
+        "over/under",
+        "goals",
+        "goals o/u",
+        "total goals",
+    },
+    "both_teams_score": {
+        "both teams score",
+        "both teams to score",
+        "btts",
+        "gg/ng",
+        "goal goal",
+    },
+}
+
+
+def _normalize_market_name(value: Optional[object]) -> str:
+    normalized = _normalize_label(value)
+    if not normalized:
+        return ""
+    for canonical, aliases in MARKET_ALIASES.items():
+        if normalized in aliases:
+            return canonical
+    return normalized
+
+
+def _normalize_label(value: Optional[object]) -> str:
+    if value is None:
+        return ""
+
+    text = str(value)
+    text = unicodedata.normalize("NFD", text)
+    text = "".join(ch for ch in text if unicodedata.category(ch) != "Mn")
+    text = text.replace(",", ".").replace("(", " ").replace(")", " ")
+    text = re.sub(r"\s+", " ", text)
+    return text.strip().lower()
+
+
+def _is_over_25_label(value: Optional[object]) -> bool:
+    normalized = _normalize_label(value)
+    if not normalized:
+        return False
+    if "over" in normalized or "mais de" in normalized:
+        return "2.5" in normalized or "25" in normalized
+    return False
+
+
+def _is_under_25_label(value: Optional[object]) -> bool:
+    normalized = _normalize_label(value)
+    if not normalized:
+        return False
+    if "under" in normalized or "menos de" in normalized:
+        return "2.5" in normalized or "25" in normalized
+    return False
 
 
 def _calculate_probability(odd: Optional[str]) -> int:
@@ -38,6 +112,7 @@ def analyze_matches(matches: List[Dict[str, object]], index: CompetitionIndex, l
             },
             "recommendedBets": [],
             "confidence": "low",
+            "analysisNotes": [],
         }
 
         odds = match.get("odds") or []
@@ -45,39 +120,74 @@ def analyze_matches(matches: List[Dict[str, object]], index: CompetitionIndex, l
             analyzed.append(entry)
             continue
 
-        market_lookup = {market.get("name"): market.get("values", []) for market in odds if isinstance(market, dict)}
+        market_lookup: Dict[str, List[Dict[str, object]]] = {}
+        for market in odds:
+            if not isinstance(market, dict):
+                continue
+            name = _normalize_market_name(market.get("name"))
+            if not name:
+                continue
+            if name not in market_lookup or not market_lookup[name]:
+                values = market.get("values")
+                if isinstance(values, list):
+                    market_lookup[name] = values
 
-        match_winner = market_lookup.get("Match Winner", [])
-        over_under = market_lookup.get("Goals Over/Under", [])
-        btts = market_lookup.get("Both Teams Score", [])
+        match_winner = market_lookup.get("match_winner", [])
+        over_under = market_lookup.get("goals_over_under", [])
+        btts = market_lookup.get("both_teams_score", [])
+
+        forebet = match.get("forebet") if isinstance(match, dict) else None
+        forebet_used = False
 
         predictions = entry["predictions"]
 
         for value in match_winner:
-            label = value.get("value")
+            label = _normalize_label(value.get("value"))
             odd = value.get("odd")
-            if label == "Home":
+            if label in HOME_LABELS:
                 predictions["homeWinProbability"] = _calculate_probability(odd)
-            elif label == "Draw":
+            elif label in DRAW_LABELS:
                 predictions["drawProbability"] = _calculate_probability(odd)
-            elif label == "Away":
+            elif label in AWAY_LABELS:
                 predictions["awayWinProbability"] = _calculate_probability(odd)
 
         for value in over_under:
             label = value.get("value")
             odd = value.get("odd")
-            if label == "Over 2.5":
+            if _is_over_25_label(label):
                 predictions["over25Probability"] = _calculate_probability(odd)
-            elif label == "Under 2.5":
+            elif _is_under_25_label(label):
                 predictions["under25Probability"] = _calculate_probability(odd)
 
         for value in btts:
-            label = value.get("value")
+            label = _normalize_label(value.get("value"))
             odd = value.get("odd")
-            if label == "Yes":
+            if label in YES_LABELS:
                 predictions["bttsYesProbability"] = _calculate_probability(odd)
-            elif label == "No":
+            elif label in NO_LABELS:
                 predictions["bttsNoProbability"] = _calculate_probability(odd)
+
+        if isinstance(forebet, dict):
+            def _apply_forebet(source_key: str, target_key: str) -> None:
+                nonlocal forebet_used
+                value = forebet.get(source_key)
+                if value is None:
+                    return
+                try:
+                    number = int(round(float(value)))
+                except (TypeError, ValueError):
+                    return
+                if predictions[target_key] == 0 and number > 0:
+                    predictions[target_key] = max(0, min(100, number))
+                    forebet_used = True
+
+            _apply_forebet("homeWinProbability", "homeWinProbability")
+            _apply_forebet("drawProbability", "drawProbability")
+            _apply_forebet("awayWinProbability", "awayWinProbability")
+            _apply_forebet("over25Probability", "over25Probability")
+            _apply_forebet("under25Probability", "under25Probability")
+            _apply_forebet("bttsYesProbability", "bttsYesProbability")
+            _apply_forebet("bttsNoProbability", "bttsNoProbability")
 
         recommendations: List[str] = []
         confidence_score = 0
@@ -110,6 +220,102 @@ def analyze_matches(matches: List[Dict[str, object]], index: CompetitionIndex, l
             recommendations.append(f"🚫 Ambos marcam: NÃO ({predictions['bttsNoProbability']}%)")
             confidence_score += 1
 
+        notes: List[str] = []
+        qualitative_boost = 0
+
+        form_data = match.get("form") if isinstance(match, dict) else {}
+        home_form = (form_data or {}).get("home") if isinstance(form_data, dict) else None
+        away_form = (form_data or {}).get("away") if isinstance(form_data, dict) else None
+        head_to_head = (form_data or {}).get("headToHead") if isinstance(form_data, dict) else None
+
+        def _format_record(record: Optional[str]) -> str:
+            return (record or "")[:5]
+
+        if home_form and isinstance(home_form, dict):
+            streak = home_form.get("currentStreak", {})
+            if isinstance(streak, dict) and streak.get("type") == "win" and streak.get("count", 0) >= 3:
+                notes.append(
+                    f"Casa com {streak.get('count')} vitórias seguidas ({_format_record(home_form.get('recentRecord'))})"
+                )
+                qualitative_boost += 1
+
+        if away_form and isinstance(away_form, dict):
+            streak = away_form.get("currentStreak", {})
+            if isinstance(streak, dict) and streak.get("type") == "loss" and streak.get("count", 0) >= 2:
+                notes.append(
+                    f"Visitante sem vencer há {streak.get('count')} jogos ({_format_record(away_form.get('recentRecord'))})"
+                )
+                qualitative_boost += 1
+
+        avg_attack = 0.0
+        if home_form and isinstance(home_form, dict):
+            avg_attack += float(home_form.get("avgGoalsFor", 0.0))
+        if away_form and isinstance(away_form, dict):
+            avg_attack += float(away_form.get("avgGoalsFor", 0.0))
+
+        if avg_attack >= 3.2:
+            notes.append("Tendência de muitos golos (médias ofensivas altas nas últimas partidas)")
+        elif avg_attack <= 2.0:
+            notes.append("Tendência de poucos golos nos últimos jogos das equipas")
+
+        if head_to_head and isinstance(head_to_head, dict):
+            if int(head_to_head.get("homeWins", 0) or 0) >= 3:
+                notes.append("Histórico recente favorável ao mandante no confronto direto")
+                qualitative_boost += 1
+            if float(head_to_head.get("avgGoalsTotal", 0.0) or 0.0) >= 3:
+                notes.append("Confrontos diretos recentes com média superior a 3 golos")
+
+        if forebet_used:
+            notes.append("Probabilidades 1X2 complementadas com dados da Forebet")
+
+        draw_rate = (
+            float(home_form.get("drawRate", 0.0)) if isinstance(home_form, dict) else 0.0
+        ) + (
+            float(away_form.get("drawRate", 0.0)) if isinstance(away_form, dict) else 0.0
+        )
+        form_count = (1 if home_form else 0) + (1 if away_form else 0) or 1
+        draw_rate /= form_count
+
+        if (
+            predictions["homeWinProbability"] == 0
+            and predictions["awayWinProbability"] == 0
+            and predictions["drawProbability"] == 0
+            and (home_form or away_form)
+        ):
+            draw_probability = round(min(draw_rate, 0.45) * 100)
+
+            home_score = 0.0
+            away_score = 0.0
+            if isinstance(home_form, dict):
+                home_score += float(home_form.get("winRate", 0.0))
+                home_score += max(float(home_form.get("goalDifferenceAvg", 0.0)), 0)
+            if isinstance(away_form, dict):
+                home_score += float(away_form.get("lossRate", 0.0)) * 0.6
+
+            if isinstance(away_form, dict):
+                away_score += float(away_form.get("winRate", 0.0))
+                away_score += max(float(away_form.get("goalDifferenceAvg", 0.0)), 0)
+            if isinstance(home_form, dict):
+                away_score += float(home_form.get("lossRate", 0.0)) * 0.6
+
+            total_score = home_score + away_score
+            available = max(0, 100 - draw_probability)
+
+            if total_score > 0:
+                entry["predictions"]["homeWinProbability"] = round((home_score / total_score) * available)
+                entry["predictions"]["awayWinProbability"] = max(
+                    0,
+                    available - entry["predictions"]["homeWinProbability"],
+                )
+            else:
+                entry["predictions"]["homeWinProbability"] = round(available / 2)
+                entry["predictions"]["awayWinProbability"] = available - entry["predictions"]["homeWinProbability"]
+
+            entry["predictions"]["drawProbability"] = draw_probability
+
+        entry["analysisNotes"] = notes[:3]
+        confidence_score += qualitative_boost
+
         entry["recommendedBets"] = recommendations
 
         if confidence_score >= 5:
@@ -122,7 +328,15 @@ def analyze_matches(matches: List[Dict[str, object]], index: CompetitionIndex, l
     confidence_rank = {"high": 3, "medium": 2, "low": 1}
 
     def score(item: Dict[str, object]) -> int:
-        return confidence_rank.get(item.get("confidence", "low"), 0) * 10 + len(item.get("recommendedBets", []))
+        predictions = item.get("predictions", {}) if isinstance(item, dict) else {}
+        max_probability = max(
+            int((predictions or {}).get("homeWinProbability", 0) or 0),
+            int((predictions or {}).get("drawProbability", 0) or 0),
+            int((predictions or {}).get("awayWinProbability", 0) or 0),
+        )
+        confidence_component = confidence_rank.get(item.get("confidence", "low"), 0) * 1000
+        bet_component = len(item.get("recommendedBets", [])) * 10
+        return confidence_component + bet_component + max_probability
 
     sorted_matches = sorted(analyzed, key=score, reverse=True)
 

--- a/python_bot/config.py
+++ b/python_bot/config.py
@@ -16,6 +16,9 @@ class Settings:
     default_chat_id: Optional[str]
     bookmaker_id: int = 6
     max_fixtures: int = 120
+    telegram_owner_id: Optional[str] = None
+    openai_api_key: Optional[str] = None
+    openai_model: str = "gpt-4o-mini"
 
 
 def load_settings(env_file: Optional[Path] = None) -> Settings:
@@ -32,8 +35,11 @@ def load_settings(env_file: Optional[Path] = None) -> Settings:
 
     channel_id = os.getenv("TELEGRAM_CHANNEL_ID")
     default_chat = os.getenv("TELEGRAM_DEFAULT_CHAT_ID")
+    owner_id = os.getenv("TELEGRAM_OWNER_ID")
     bookmaker = int(os.getenv("FOOTBALL_API_BOOKMAKER", "6"))
     max_fixtures = int(os.getenv("FOOTBALL_MAX_FIXTURES", "120"))
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    openai_model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 
     return Settings(
         football_api_key=api_key,
@@ -42,4 +48,7 @@ def load_settings(env_file: Optional[Path] = None) -> Settings:
         default_chat_id=default_chat,
         bookmaker_id=bookmaker,
         max_fixtures=max_fixtures,
+        telegram_owner_id=owner_id,
+        openai_api_key=openai_api_key,
+        openai_model=openai_model,
     )

--- a/python_bot/fetcher.py
+++ b/python_bot/fetcher.py
@@ -3,16 +3,210 @@ from __future__ import annotations
 import logging
 import time
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import requests
 
 from .competitions import CompetitionIndex
 from .config import Settings
+from .forebet import ForebetClient
 
 
 class FetchError(RuntimeError):
     pass
+
+
+def _extract_score(fixture: Dict[str, object]) -> Tuple[int, int]:
+    goals = fixture.get("goals") or {}
+    score = fixture.get("score") or {}
+    full_time = score.get("fulltime") or {}
+    extra_time = score.get("extratime") or {}
+    penalties = score.get("penalty") or {}
+
+    home = goals.get("home")
+    away = goals.get("away")
+
+    if home is None:
+        home = full_time.get("home") or extra_time.get("home") or penalties.get("home") or 0
+    if away is None:
+        away = full_time.get("away") or extra_time.get("away") or penalties.get("away") or 0
+
+    try:
+        return int(home), int(away)
+    except (TypeError, ValueError):
+        return 0, 0
+
+
+def _summarize_team_form(team_id: Optional[int], fixtures: List[Dict[str, object]]) -> Optional[Dict[str, object]]:
+    if not team_id or not fixtures:
+        return None
+
+    ordered = sorted(fixtures, key=lambda item: (item.get("fixture", {}) or {}).get("timestamp", 0) or 0, reverse=True)
+
+    matches: List[Dict[str, object]] = []
+    wins = draws = losses = goals_for = goals_against = clean_sheets = failed_to_score = 0
+
+    for fixture in ordered:
+        home_goals, away_goals = _extract_score(fixture)
+        teams = fixture.get("teams", {}) or {}
+        home_team = (teams.get("home") or {}).get("id")
+        away_team = (teams.get("away") or {}).get("id")
+        is_home = home_team == team_id
+        opponent = teams.get("away") if is_home else teams.get("home")
+
+        winner = None
+        home_winner = (teams.get("home") or {}).get("winner")
+        away_winner = (teams.get("away") or {}).get("winner")
+        if home_winner is True and away_winner is False:
+            winner = "home"
+        elif home_winner is False and away_winner is True:
+            winner = "away"
+        elif home_goals > away_goals:
+            winner = "home"
+        elif away_goals > home_goals:
+            winner = "away"
+        else:
+            winner = "draw"
+
+        result_code = "E" if winner == "draw" else ("V" if winner == ("home" if is_home else "away") else "D")
+
+        matches.append(
+            {
+                "fixtureId": (fixture.get("fixture") or {}).get("id"),
+                "date": (fixture.get("fixture") or {}).get("date"),
+                "opponent": (opponent or {}).get("name"),
+                "competition": (fixture.get("league") or {}).get("name"),
+                "score": f"{home_goals}-{away_goals}",
+                "result": result_code,
+            }
+        )
+
+        goals_for_match = home_goals if is_home else away_goals
+        goals_against_match = away_goals if is_home else home_goals
+
+        goals_for += goals_for_match
+        goals_against += goals_against_match
+
+        if result_code == "V":
+            wins += 1
+        elif result_code == "E":
+            draws += 1
+        else:
+            losses += 1
+
+        if goals_against_match == 0:
+            clean_sheets += 1
+        if goals_for_match == 0:
+            failed_to_score += 1
+
+    total = len(matches)
+    if total == 0:
+        return None
+
+    recent_record = "".join(match["result"] for match in matches)
+    first_result = matches[0]["result"]
+    streak_count = 0
+    for match in matches:
+        if match["result"] == first_result:
+            streak_count += 1
+        else:
+            break
+
+    streak_type = "draw"
+    if first_result == "V":
+        streak_type = "win"
+    elif first_result == "D":
+        streak_type = "loss"
+
+    avg_goals_for = round(goals_for / total, 2)
+    avg_goals_against = round(goals_against / total, 2)
+
+    return {
+        "sampleSize": total,
+        "matches": matches,
+        "wins": wins,
+        "draws": draws,
+        "losses": losses,
+        "winRate": wins / total if total else 0,
+        "drawRate": draws / total if total else 0,
+        "lossRate": losses / total if total else 0,
+        "formPoints": wins * 3 + draws,
+        "avgGoalsFor": avg_goals_for,
+        "avgGoalsAgainst": avg_goals_against,
+        "avgGoalsTotal": round((goals_for + goals_against) / total, 2),
+        "goalDifferenceAvg": round(avg_goals_for - avg_goals_against, 2),
+        "cleanSheets": clean_sheets,
+        "failedToScore": failed_to_score,
+        "recentRecord": recent_record,
+        "currentStreak": {"type": streak_type, "count": streak_count},
+    }
+
+
+def _summarize_head_to_head(home_id: Optional[int], away_id: Optional[int], fixtures: List[Dict[str, object]]) -> Optional[Dict[str, object]]:
+    if not home_id or not away_id or not fixtures:
+        return None
+
+    ordered = sorted(fixtures, key=lambda item: (item.get("fixture", {}) or {}).get("timestamp", 0) or 0, reverse=True)
+
+    matches: List[Dict[str, object]] = []
+    home_wins = away_wins = draws = 0
+    total_goals = 0
+
+    for fixture in ordered:
+        home_goals, away_goals = _extract_score(fixture)
+        teams = fixture.get("teams", {}) or {}
+        fixture_home = (teams.get("home") or {}).get("id")
+        upcoming_home_was_home = fixture_home == home_id
+
+        home_winner = (teams.get("home") or {}).get("winner")
+        away_winner = (teams.get("away") or {}).get("winner")
+
+        upcoming_home_won: Optional[bool]
+        if home_winner is True and away_winner is False:
+            upcoming_home_won = upcoming_home_was_home
+        elif home_winner is False and away_winner is True:
+            upcoming_home_won = not upcoming_home_was_home
+        elif home_goals > away_goals:
+            upcoming_home_won = upcoming_home_was_home
+        elif away_goals > home_goals:
+            upcoming_home_won = not upcoming_home_was_home
+        else:
+            upcoming_home_won = None
+
+        if upcoming_home_won is None:
+            result_code = "E"
+            draws += 1
+        elif upcoming_home_won:
+            result_code = "V"
+            home_wins += 1
+        else:
+            result_code = "D"
+            away_wins += 1
+
+        matches.append(
+            {
+                "fixtureId": (fixture.get("fixture") or {}).get("id"),
+                "date": (fixture.get("fixture") or {}).get("date"),
+                "venue": ((fixture.get("fixture") or {}).get("venue") or {}).get("name"),
+                "score": f"{home_goals}-{away_goals}",
+                "result": result_code,
+            }
+        )
+
+        total_goals += home_goals + away_goals
+
+    sample_size = len(matches)
+    if sample_size == 0:
+        return None
+
+    return {
+        "sampleSize": sample_size,
+        "matches": matches,
+        "homeWins": home_wins,
+        "awayWins": away_wins,
+        "draws": draws,
+        "avgGoalsTotal": round(total_goals / sample_size, 2),
+    }
 
 
 def fetch_matches(
@@ -61,6 +255,64 @@ def fetch_matches(
     region_counters = {region: 0 for region in index.region_order}
     matches: List[Dict[str, object]] = []
 
+    team_form_cache: Dict[int, Optional[Dict[str, object]]] = {}
+    head_to_head_cache: Dict[Tuple[int, int], Optional[Dict[str, object]]] = {}
+    forebet_client = ForebetClient(logger=logger)
+
+    def get_team_form(team_id: Optional[int]) -> Optional[Dict[str, object]]:
+        if not team_id:
+            return None
+        if team_id in team_form_cache:
+            return team_form_cache[team_id]
+
+        try:
+            response = requests.get(
+                "https://v3.football.api-sports.io/fixtures",
+                params={"team": team_id, "last": 5},
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            fixtures = payload.get("response", [])
+            summary = _summarize_team_form(team_id, fixtures)
+            team_form_cache[team_id] = summary
+            time.sleep(0.15)
+            return summary
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.warning("Failed to fetch team form", extra={"teamId": team_id, "error": str(exc)})
+            team_form_cache[team_id] = None
+            return None
+
+    def get_head_to_head(home_id: Optional[int], away_id: Optional[int]) -> Optional[Dict[str, object]]:
+        if not home_id or not away_id:
+            return None
+        key = (home_id, away_id)
+        if key in head_to_head_cache:
+            return head_to_head_cache[key]
+
+        try:
+            response = requests.get(
+                "https://v3.football.api-sports.io/fixtures/headtohead",
+                params={"h2h": f"{home_id}-{away_id}", "last": 5},
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            fixtures = payload.get("response", [])
+            summary = _summarize_head_to_head(home_id, away_id, fixtures)
+            head_to_head_cache[key] = summary
+            time.sleep(0.15)
+            return summary
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.warning(
+                "Failed to fetch head-to-head",
+                extra={"homeId": home_id, "awayId": away_id, "error": str(exc)},
+            )
+            head_to_head_cache[key] = None
+            return None
+
     for fixture in fixtures_to_process:
         competition = index.identify(fixture.get("league"))
         if not competition:
@@ -71,19 +323,34 @@ def fetch_matches(
         if not fixture_id:
             continue
 
-        odds_data = None
+        odds_data: List[Dict[str, object]] = []
         odds_response = requests.get(
             "https://v3.football.api-sports.io/odds",
-            params={"fixture": fixture_id, "bookmaker": settings.bookmaker_id},
+            params={"fixture": fixture_id},
             headers=headers,
             timeout=30,
         )
         if odds_response.status_code == 200:
             odds_payload = odds_response.json()
             try:
-                odds_data = odds_payload["response"][0]["bookmakers"][0]["bets"]
+                bookmakers = odds_payload["response"][0]["bookmakers"]
             except (KeyError, IndexError, TypeError):
-                odds_data = []
+                bookmakers = []
+
+            seen_markets: Dict[str, List[Dict[str, object]]] = {}
+            for bookmaker in bookmakers or []:
+                bets = bookmaker.get("bets") or []
+                for bet in bets:
+                    name = bet.get("name")
+                    if not isinstance(name, str):
+                        continue
+                    if name not in seen_markets or not seen_markets[name]:
+                        seen_markets[name] = bet.get("values") or []
+
+            odds_data = [
+                {"name": market_name, "values": values}
+                for market_name, values in seen_markets.items()
+            ]
         else:
             logger.warning(
                 "Failed to fetch odds",
@@ -98,6 +365,32 @@ def fetch_matches(
                 time_str = dt.strftime("%H:%M")
             except ValueError:
                 time_str = date_str
+
+        home_team = fixture.get("teams", {}).get("home", {})
+        away_team = fixture.get("teams", {}).get("away", {})
+
+        home_form = get_team_form(home_team.get("id"))
+        away_form = get_team_form(away_team.get("id"))
+        head_to_head = get_head_to_head(home_team.get("id"), away_team.get("id"))
+
+        forebet_prediction = forebet_client.get_probabilities(
+            date,
+            home_team.get("name"),
+            away_team.get("name"),
+        )
+
+        forebet_data = None
+        if forebet_prediction:
+            forebet_data = {
+                "source": "Forebet",
+                "homeWinProbability": forebet_prediction.home,
+                "drawProbability": forebet_prediction.draw,
+                "awayWinProbability": forebet_prediction.away,
+                "over25Probability": forebet_prediction.over25,
+                "under25Probability": forebet_prediction.under25,
+                "bttsYesProbability": forebet_prediction.btts_yes,
+                "bttsNoProbability": forebet_prediction.btts_no,
+            }
 
         match_entry = {
             "fixtureId": fixture_id,
@@ -117,16 +410,22 @@ def fetch_matches(
             },
             "teams": {
                 "home": {
-                    "name": fixture.get("teams", {}).get("home", {}).get("name"),
-                    "logo": fixture.get("teams", {}).get("home", {}).get("logo"),
+                    "name": home_team.get("name"),
+                    "logo": home_team.get("logo"),
                 },
                 "away": {
-                    "name": fixture.get("teams", {}).get("away", {}).get("name"),
-                    "logo": fixture.get("teams", {}).get("away", {}).get("logo"),
+                    "name": away_team.get("name"),
+                    "logo": away_team.get("logo"),
                 },
             },
             "venue": fixture_info.get("venue", {}).get("name") or "TBD",
             "odds": odds_data,
+            "forebet": forebet_data,
+            "form": {
+                "home": home_form,
+                "away": away_form,
+                "headToHead": head_to_head,
+            },
         }
 
         matches.append(match_entry)

--- a/python_bot/forebet.py
+++ b/python_bot/forebet.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+
+FOREBET_URL_TEMPLATE = "https://www.forebet.com/en/football-tips-and-predictions-for-{slug}"
+
+
+@dataclass
+class ForebetProbabilities:
+    home: int
+    draw: int
+    away: int
+    over25: Optional[int] = None
+    under25: Optional[int] = None
+    btts_yes: Optional[int] = None
+    btts_no: Optional[int] = None
+
+
+def _normalize_team(name: Optional[str]) -> str:
+    if not name:
+        return ""
+    text = unicodedata.normalize("NFD", str(name))
+    text = "".join(ch for ch in text if unicodedata.category(ch) != "Mn")
+    text = re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
+    return text
+
+
+def _build_key(home: Optional[str], away: Optional[str]) -> str:
+    return f"{_normalize_team(home)}|{_normalize_team(away)}"
+
+
+def _parse_percentage(value: Optional[str]) -> Optional[int]:
+    if not value:
+        return None
+    match = re.search(r"(-?\d+(?:\.\d+)?)\s*%", value)
+    if not match:
+        return None
+    try:
+        return max(0, min(100, round(float(match.group(1)))))
+    except ValueError:
+        return None
+
+
+class ForebetClient:
+    """Lightweight scraper for Forebet daily predictions."""
+
+    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+            }
+        )
+        self._cache: Dict[str, Dict[str, ForebetProbabilities]] = {}
+        self._logger = logger or logging.getLogger(__name__)
+
+    def _get_slug(self, date: datetime) -> str:
+        today = datetime.utcnow().date()
+        if date.date() == today:
+            return "today"
+        return date.strftime("%Y-%m-%d")
+
+    def _load_page(self, date: datetime) -> Optional[str]:
+        slug = self._get_slug(date)
+        url = FOREBET_URL_TEMPLATE.format(slug=slug)
+        try:
+            response = self._session.get(url, timeout=30)
+            if response.status_code != 200:
+                self._logger.warning(
+                    "Forebet request failed", extra={"url": url, "status": response.status_code}
+                )
+                return None
+            return response.text
+        except Exception as exc:  # noqa: BLE001
+            self._logger.warning("Unable to fetch Forebet page", extra={"error": str(exc), "url": url})
+            return None
+
+    def _parse_match_table(self, html: str) -> Dict[str, ForebetProbabilities]:
+        soup = BeautifulSoup(html, "html.parser")
+        tables = soup.select("table")
+        results: Dict[str, ForebetProbabilities] = {}
+
+        for table in tables:
+            rows = table.find_all("tr")
+            for row in rows:
+                cells = row.find_all("td")
+                if len(cells) < 3:
+                    continue
+
+                # Attempt to locate team names
+                home_cell = row.find(class_=re.compile(r"home|tnms|team1", re.IGNORECASE))
+                away_cell = row.find(class_=re.compile(r"away|tnms2|team2", re.IGNORECASE))
+                home_team = home_cell.get_text(strip=True) if home_cell else None
+                away_team = away_cell.get_text(strip=True) if away_cell else None
+
+                if not home_team or not away_team:
+                    # fallback: assume first text-dominant cells are teams
+                    text_cells = [
+                        cell.get_text(" ", strip=True)
+                        for cell in cells
+                        if len(cell.get_text(strip=True)) > 0
+                    ]
+                    if len(text_cells) >= 3:
+                        home_team = home_team or text_cells[1]
+                        away_team = away_team or text_cells[2]
+
+                if not home_team or not away_team:
+                    continue
+
+                percentages: list[int] = []
+                for cell in cells:
+                    percent = _parse_percentage(cell.get_text(" ", strip=True))
+                    if percent is not None:
+                        percentages.append(percent)
+
+                if len(percentages) < 3:
+                    continue
+
+                key = _build_key(home_team, away_team)
+                if not key or key in results:
+                    continue
+
+                home_prob, draw_prob, away_prob = percentages[:3]
+
+                # Attempt to capture Over/Under and BTTS if the row exposes more columns
+                over_prob = under_prob = btts_yes = btts_no = None
+                if len(percentages) >= 5:
+                    over_prob = percentages[3]
+                    under_prob = percentages[4]
+                if len(percentages) >= 7:
+                    btts_yes = percentages[5]
+                    btts_no = percentages[6]
+
+                results[key] = ForebetProbabilities(
+                    home=home_prob,
+                    draw=draw_prob,
+                    away=away_prob,
+                    over25=over_prob,
+                    under25=under_prob,
+                    btts_yes=btts_yes,
+                    btts_no=btts_no,
+                )
+
+        return results
+
+    def _load_predictions(self, date: datetime) -> Dict[str, ForebetProbabilities]:
+        iso = date.strftime("%Y-%m-%d")
+        if iso in self._cache:
+            return self._cache[iso]
+
+        html = self._load_page(date)
+        if not html:
+            self._cache[iso] = {}
+            return {}
+
+        parsed = self._parse_match_table(html)
+        self._cache[iso] = parsed
+        return parsed
+
+    def get_probabilities(
+        self, date: datetime, home_team: Optional[str], away_team: Optional[str]
+    ) -> Optional[ForebetProbabilities]:
+        if not home_team or not away_team:
+            return None
+
+        predictions = self._load_predictions(date)
+        if not predictions:
+            return None
+
+        key = _build_key(home_team, away_team)
+        data = predictions.get(key)
+        if data:
+            return data
+
+        reverse = predictions.get(_build_key(away_team, home_team))
+        if reverse:
+            return ForebetProbabilities(
+                home=reverse.away,
+                draw=reverse.draw,
+                away=reverse.home,
+                over25=reverse.over25,
+                under25=reverse.under25,
+                btts_yes=reverse.btts_yes,
+                btts_no=reverse.btts_no,
+            )
+
+        return None

--- a/python_bot/llm.py
+++ b/python_bot/llm.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class ChatGPTClient:
+    """Simple wrapper around the OpenAI Chat Completions API."""
+
+    def __init__(self, api_key: Optional[str], model: str = "gpt-4o-mini", logger: Optional[logging.Logger] = None) -> None:
+        self.api_key = api_key
+        self.model = model
+        self.logger = logger or logging.getLogger(__name__)
+
+    def is_configured(self) -> bool:
+        return bool(self.api_key and self.model)
+
+    def summarize_match(self, context: Dict[str, Any]) -> Optional[str]:
+        if not self.is_configured():
+            return None
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "Você é um analista de apostas esportivas que cria insights objetivos e concisos. "
+                        "Resuma os dados recebidos em português europeu, indicando onde há oportunidades e riscos."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "Use os dados JSON abaixo para elaborar um parágrafo curto com duas a quatro frases "
+                        "destacando: estado atual das equipas, tendências de golos e indicações de aposta baseadas nas probabilidades.\n"
+                        f"Dados: {json.dumps(context, ensure_ascii=False)}"
+                    ),
+                },
+            ],
+            "temperature": 0.3,
+            "max_tokens": 250,
+        }
+
+        try:
+            response = requests.post(
+                "https://api.openai.com/v1/chat/completions",
+                headers=headers,
+                json=payload,
+                timeout=45,
+            )
+            response.raise_for_status()
+            data = response.json()
+            choices = data.get("choices") or []
+            if not choices:
+                return None
+            message = choices[0].get("message") or {}
+            content = message.get("content")
+            if isinstance(content, str):
+                return content.strip()
+            return None
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning("Falha ao obter resumo do ChatGPT", exc_info=exc)
+            return None

--- a/python_bot/manual_fetcher.py
+++ b/python_bot/manual_fetcher.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Dict, Optional, Tuple
+
+import requests
+
+from .competitions import CompetitionIndex
+from .config import Settings
+from .fetcher import _summarize_head_to_head, _summarize_team_form  # type: ignore
+from .forebet import ForebetClient
+
+API_BASE = "https://v3.football.api-sports.io"
+
+
+def _headers(settings: Settings) -> Dict[str, str]:
+    return {
+        "X-RapidAPI-Key": settings.football_api_key,
+        "X-RapidAPI-Host": "v3.football.api-sports.io",
+    }
+
+
+def _search_team(query: str, settings: Settings, logger: logging.Logger) -> Optional[Dict[str, object]]:
+    if not query:
+        return None
+    try:
+        response = requests.get(
+            f"{API_BASE}/teams",
+            params={"search": query.strip()},
+            headers=_headers(settings),
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Falha ao procurar equipa", extra={"query": query, "error": str(exc)})
+        return None
+
+    for item in payload.get("response", []) or []:
+        team = item.get("team") or {}
+        if not isinstance(team, dict):
+            continue
+        return team
+    return None
+
+
+def _pick_upcoming_fixture(fixtures: list[Dict[str, object]]) -> Optional[Dict[str, object]]:
+    upcoming = []
+    for fixture in fixtures or []:
+        info = fixture.get("fixture") or {}
+        timestamp = info.get("timestamp")
+        status = ((info.get("status") or {}).get("short") or "").upper()
+        if status in {"FT", "AET", "PEN", "POST", "CAN"}:
+            continue
+        upcoming.append((timestamp or 0, fixture))
+    if not upcoming:
+        return None
+    upcoming.sort(key=lambda item: item[0] or 0)
+    return upcoming[0][1]
+
+
+def _fetch_next_fixture_for_team(team_id: int, settings: Settings, logger: logging.Logger) -> Optional[Dict[str, object]]:
+    try:
+        response = requests.get(
+            f"{API_BASE}/fixtures",
+            params={"team": team_id, "next": 5},
+            headers=_headers(settings),
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Falha ao obter próximos jogos", extra={"teamId": team_id, "error": str(exc)})
+        return None
+
+    fixture = _pick_upcoming_fixture(payload.get("response", []) or [])
+    return fixture
+
+
+def _fetch_fixture_between(team_a: int, team_b: int, settings: Settings, logger: logging.Logger) -> Optional[Dict[str, object]]:
+    try:
+        response = requests.get(
+            f"{API_BASE}/fixtures/headtohead",
+            params={"h2h": f"{team_a}-{team_b}", "next": 1},
+            headers=_headers(settings),
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Falha ao procurar confronto direto futuro",
+            extra={"homeId": team_a, "awayId": team_b, "error": str(exc)},
+        )
+        payload = {"response": []}
+
+    fixture = _pick_upcoming_fixture(payload.get("response", []) or [])
+    if fixture:
+        return fixture
+
+    # fallback: procure entre os próximos jogos do primeiro clube
+    try:
+        alt = requests.get(
+            f"{API_BASE}/fixtures",
+            params={"team": team_a, "next": 10},
+            headers=_headers(settings),
+            timeout=30,
+        )
+        alt.raise_for_status()
+        candidates = alt.json().get("response", []) or []
+    except Exception:
+        return None
+
+    for candidate in candidates:
+        teams = candidate.get("teams") or {}
+        away = (teams.get("away") or {}).get("id")
+        home = (teams.get("home") or {}).get("id")
+        if away == team_b or home == team_b:
+            status = ((candidate.get("fixture") or {}).get("status") or {}).get("short")
+            if status and status.upper() in {"FT", "AET", "PEN", "CAN", "POST"}:
+                continue
+            return candidate
+    return None
+
+
+def _fetch_odds(fixture_id: int, settings: Settings, logger: logging.Logger) -> list[Dict[str, object]]:
+    try:
+        response = requests.get(
+            f"{API_BASE}/odds",
+            params={"fixture": fixture_id},
+            headers=_headers(settings),
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        response_items = payload.get("response") or []
+        bookmakers = []
+        if response_items:
+            first_item = response_items[0] or {}
+            bookmakers = first_item.get("bookmakers") or []
+
+        seen_markets: dict[str, list[dict[str, object]]] = {}
+        for bookmaker in bookmakers:
+            for bet in bookmaker.get("bets", []):
+                name = bet.get("name")
+                if not isinstance(name, str):
+                    continue
+                if name not in seen_markets or not seen_markets[name]:
+                    seen_markets[name] = bet.get("values") or []
+
+        return [{"name": market, "values": values} for market, values in seen_markets.items()]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Não foi possível obter odds para o fixture",
+            extra={"fixtureId": fixture_id, "error": str(exc)},
+        )
+        return []
+
+
+def _build_match_entry(
+    fixture: Dict[str, object],
+    settings: Settings,
+    index: CompetitionIndex,
+    logger: logging.Logger,
+) -> Dict[str, object]:
+    fixture_info = fixture.get("fixture", {}) or {}
+    fixture_id = fixture_info.get("id")
+    if not fixture_id:
+        raise ValueError("fixture_id ausente no payload")
+
+    odds = _fetch_odds(int(fixture_id), settings, logger)
+
+    league = fixture.get("league", {}) or {}
+    competition = index.identify(league)
+
+    if competition:
+        competition_info = {
+            "key": competition.key,
+            "name": competition.display_name,
+            "region": competition.region,
+            "type": competition.type,
+            "country": competition.country,
+        }
+    else:
+        competition_info = {
+            "key": str(league.get("id") or "unknown"),
+            "name": league.get("name") or "Competição desconhecida",
+            "region": league.get("country") or "Outros",
+            "type": league.get("type") or "league",
+            "country": league.get("country"),
+        }
+
+    def _format_time(date_str: Optional[str]) -> str:
+        if not date_str:
+            return ""
+        try:
+            dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+            return dt.strftime("%H:%M")
+        except ValueError:
+            return ""
+
+    teams = fixture.get("teams", {}) or {}
+    home = teams.get("home") or {}
+    away = teams.get("away") or {}
+
+    home_id = home.get("id")
+    away_id = away.get("id")
+
+    home_form = _summarize_team_form(home_id, _fetch_recent_matches(home_id, settings, logger)) if home_id else None
+    away_form = _summarize_team_form(away_id, _fetch_recent_matches(away_id, settings, logger)) if away_id else None
+    head_to_head = (
+        _summarize_head_to_head(home_id, away_id, _fetch_head_to_head_matches(home_id, away_id, settings, logger))
+        if home_id and away_id
+        else None
+    )
+
+    forebet_client = ForebetClient(logger=logger)
+    forebet_prediction = forebet_client.get_probabilities(
+        datetime.fromisoformat(fixture_info.get("date", "0").replace("Z", "+00:00")) if fixture_info.get("date") else datetime.utcnow(),
+        home.get("name"),
+        away.get("name"),
+    )
+
+    if forebet_prediction:
+        forebet_data = {
+            "source": "Forebet",
+            "homeWinProbability": forebet_prediction.home,
+            "drawProbability": forebet_prediction.draw,
+            "awayWinProbability": forebet_prediction.away,
+            "over25Probability": forebet_prediction.over25,
+            "under25Probability": forebet_prediction.under25,
+            "bttsYesProbability": forebet_prediction.btts_yes,
+            "bttsNoProbability": forebet_prediction.btts_no,
+        }
+    else:
+        forebet_data = None
+
+    return {
+        "fixtureId": fixture_id,
+        "date": fixture_info.get("date"),
+        "time": _format_time(fixture_info.get("date")),
+        "league": {
+            "name": league.get("name"),
+            "country": league.get("country"),
+            "logo": league.get("logo"),
+        },
+        "competition": competition_info,
+        "teams": {
+            "home": {"name": home.get("name"), "logo": home.get("logo")},
+            "away": {"name": away.get("name"), "logo": away.get("logo")},
+        },
+        "venue": ((fixture_info.get("venue") or {}) or {}).get("name") or "TBD",
+        "odds": odds,
+        "forebet": forebet_data,
+        "form": {
+            "home": home_form,
+            "away": away_form,
+            "headToHead": head_to_head,
+        },
+    }
+
+
+def _fetch_recent_matches(team_id: int, settings: Settings, logger: logging.Logger) -> list[Dict[str, object]]:
+    try:
+        response = requests.get(
+            f"{API_BASE}/fixtures",
+            params={"team": team_id, "last": 5},
+            headers=_headers(settings),
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload.get("response", []) or []
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Falha ao obter forma recente", extra={"teamId": team_id, "error": str(exc)})
+        return []
+
+
+def _fetch_head_to_head_matches(
+    home_id: int,
+    away_id: int,
+    settings: Settings,
+    logger: logging.Logger,
+) -> list[Dict[str, object]]:
+    try:
+        response = requests.get(
+            f"{API_BASE}/fixtures/headtohead",
+            params={"h2h": f"{home_id}-{away_id}", "last": 5},
+            headers=_headers(settings),
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload.get("response", []) or []
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Falha ao obter histórico recente",
+            extra={"homeId": home_id, "awayId": away_id, "error": str(exc)},
+        )
+        return []
+
+
+def locate_fixture(
+    query: str,
+    settings: Settings,
+    index: CompetitionIndex,
+    logger: logging.Logger,
+) -> Tuple[Optional[Dict[str, object]], Optional[str]]:
+    """Return a match entry and optional error message for the supplied query."""
+
+    normalized = query.strip()
+    if not normalized:
+        return None, "Forneça o nome de uma equipa ou o confronto (ex.: city-psg)."
+
+    separators = {"-", "x", "vs", "v", "X", "VS"}
+    opponent = None
+    for sep in separators:
+        if sep in normalized:
+            parts = [part.strip() for part in normalized.split(sep) if part.strip()]
+            if len(parts) >= 2:
+                normalized = parts[0]
+                opponent = parts[1]
+                break
+
+    team = _search_team(normalized, settings, logger)
+    if not team:
+        return None, f"Não encontrei a equipa '{normalized}'."
+
+    team_id = team.get("id")
+    if not isinstance(team_id, int):
+        return None, f"Resposta inesperada ao procurar '{normalized}'."
+
+    if opponent:
+        other = _search_team(opponent, settings, logger)
+        if not other:
+            return None, f"Não encontrei a equipa '{opponent}'."
+        other_id = other.get("id")
+        if not isinstance(other_id, int):
+            return None, "Resposta inesperada ao procurar o adversário."
+        fixture = _fetch_fixture_between(team_id, other_id, settings, logger)
+        if not fixture:
+            return None, "Não encontrei um confronto agendado entre as equipas."
+    else:
+        fixture = _fetch_next_fixture_for_team(team_id, settings, logger)
+        if not fixture:
+            return None, "A equipa não tem jogos agendados nos próximos dias."
+
+    try:
+        match_entry = _build_match_entry(fixture, settings, index, logger)
+        return match_entry, None
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Erro ao preparar fixture para análise", exc_info=exc)
+        return None, "Não foi possível preparar os dados do jogo."

--- a/python_bot/message_builder.py
+++ b/python_bot/message_builder.py
@@ -61,6 +61,9 @@ def format_predictions_message(match_data: Dict[str, object], analysis: Dict[str
                         away=predictions.get("awayWinProbability", 0),
                     )
                 )
+            notes = match.get("analysisNotes") or []
+            if notes:
+                message_lines.append(f"📝 PK: {' • '.join(notes[:2])}")
             message_lines.append("")
     else:
         message_lines.append("😔 <b>Não há jogos com odds interessantes hoje.</b>")

--- a/python_bot/owner_command.py
+++ b/python_bot/owner_command.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from typing import Optional
+
+import requests
+
+from .analyzer import analyze_matches
+from .competitions import load_index
+from .config import load_settings
+from .llm import ChatGPTClient
+from .manual_fetcher import locate_fixture
+from .telegram_client import TelegramClient
+
+COMMAND_ALIASES = {"/insight", "/insights", "/analise", "/analisar"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Listener de comandos privados para o owner")
+    parser.add_argument("--env", help="Caminho opcional para ficheiro .env", default=None)
+    parser.add_argument("--verbose", action="store_true", help="Ativa logs detalhados")
+    parser.add_argument("--poll-interval", type=int, default=5, help="Pausa (s) entre chamadas em caso de erro")
+    return parser.parse_args()
+
+
+def extract_command(text: Optional[str]) -> Optional[tuple[str, str]]:
+    if not text:
+        return None
+    stripped = text.strip()
+    if not stripped.startswith("/"):
+        return None
+    first_token = stripped.split()[0]
+    command = first_token.split("@", 1)[0].lower()
+    if command not in COMMAND_ALIASES:
+        return None
+    query = stripped[len(first_token) :].strip()
+    return command, query
+
+
+def build_response_message(match: dict, analysis: dict, gpt_summary: Optional[str]) -> str:
+    teams = match.get("teams", {}) or {}
+    home = (teams.get("home") or {}).get("name", "Casa")
+    away = (teams.get("away") or {}).get("name", "Fora")
+    competition = match.get("competition", {}) or {}
+    league_name = competition.get("name") or (match.get("league") or {}).get("name")
+    region = competition.get("region") or competition.get("country") or ""
+    kickoff_date = match.get("date") or ""
+    kickoff_time = match.get("time") or ""
+
+    predictions = analysis.get("predictions", {})
+    recs = analysis.get("recommendedBets", []) or []
+    notes = analysis.get("analysisNotes", []) or []
+    confidence = analysis.get("confidence", "low")
+
+    lines = [
+        "🔒 <b>Pedido do owner</b>",
+        f"🏟️ {home} vs {away}",
+    ]
+    competition_line = league_name or "Competição desconhecida"
+    if region:
+        competition_line += f" · {region}"
+    lines.append(f"🏆 {competition_line}")
+    if kickoff_date or kickoff_time:
+        display_time = kickoff_time or "--:--"
+        lines.append(f"🗓️ {kickoff_date} · {display_time}")
+
+    lines.append("")
+    lines.append("📊 Probabilidades estimadas")
+    lines.append(f"• Casa: {predictions.get('homeWinProbability', 0)}%")
+    lines.append(f"• Empate: {predictions.get('drawProbability', 0)}%")
+    lines.append(f"• Fora: {predictions.get('awayWinProbability', 0)}%")
+    lines.append(f"• Over 2.5: {predictions.get('over25Probability', 0)}% | Under 2.5: {predictions.get('under25Probability', 0)}%")
+    lines.append(
+        f"• BTTS Sim: {predictions.get('bttsYesProbability', 0)}% | BTTS Não: {predictions.get('bttsNoProbability', 0)}%"
+    )
+
+    lines.append("")
+    confidence_label = {"high": "Alta", "medium": "Média"}.get(confidence, "Baixa")
+    lines.append(f"🔥 Confiança geral: {confidence_label}")
+
+    if recs:
+        lines.append("")
+        lines.append("🎯 Sugestões do modelo:")
+        for rec in recs:
+            lines.append(f"• {rec}")
+
+    if notes:
+        lines.append("")
+        lines.append("🧠 PKs em destaque:")
+        for note in notes:
+            lines.append(f"• {note}")
+
+    if gpt_summary:
+        lines.append("")
+        lines.append("🤖 <b>Resumo GPT</b>")
+        lines.append(gpt_summary)
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+    logger = logging.getLogger("owner-command")
+
+    try:
+        settings = load_settings(args.env)
+    except RuntimeError as exc:
+        logger.error("Erro ao carregar configuração: %s", exc)
+        return 1
+
+    if not settings.telegram_owner_id:
+        logger.error("Configure TELEGRAM_OWNER_ID para usar o comando exclusivo do owner.")
+        return 1
+
+    index = load_index()
+    telegram = TelegramClient(settings, logger=logger)
+    chatgpt = ChatGPTClient(settings.openai_api_key, settings.openai_model, logger=logger)
+
+    offset: Optional[int] = None
+
+    logger.info("Iniciando listener de comandos do owner")
+
+    while True:
+        try:
+            params = {"timeout": 55}
+            if offset is not None:
+                params["offset"] = offset
+            response = requests.get(f"{telegram.base_url}/getUpdates", params=params, timeout=60)
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Falha ao obter updates do Telegram: %s", exc)
+            time.sleep(max(1, args.poll_interval))
+            continue
+
+        for update in payload.get("result", []) or []:
+            offset = max(offset or 0, update.get("update_id", 0) + 1)
+            message = update.get("message") or update.get("edited_message") or {}
+            chat = message.get("chat") or {}
+            chat_id = chat.get("id")
+            if not chat_id:
+                continue
+
+            command = extract_command(message.get("text"))
+            if not command:
+                continue
+
+            if str(message.get("from", {}).get("id")) != str(settings.telegram_owner_id):
+                telegram.send_message("Este comando é reservado ao owner.", chat_id=str(chat_id))
+                logger.info("Comando ignorado por utilizador não autorizado", extra={"chatId": chat_id})
+                continue
+
+            _, query = command
+            match, error = locate_fixture(query, settings, index, logger)
+            if error:
+                telegram.send_message(error, chat_id=str(chat_id))
+                continue
+            if not match:
+                telegram.send_message("Não foi possível localizar jogo para análise.", chat_id=str(chat_id))
+                continue
+
+            analysis = analyze_matches([match], index, logger=logger)
+            best_matches = analysis.get("bestMatches", []) or []
+            if best_matches:
+                match_analysis = best_matches[0]
+            else:
+                match_analysis = {
+                    "predictions": {
+                        "homeWinProbability": 0,
+                        "drawProbability": 0,
+                        "awayWinProbability": 0,
+                        "over25Probability": 0,
+                        "under25Probability": 0,
+                        "bttsYesProbability": 0,
+                        "bttsNoProbability": 0,
+                    },
+                    "recommendedBets": [],
+                    "analysisNotes": [],
+                    "confidence": "low",
+                }
+
+            gpt_context = {
+                "teams": match.get("teams"),
+                "competition": match.get("competition"),
+                "predictions": match_analysis.get("predictions", {}),
+                "recommendedBets": match_analysis.get("recommendedBets", []),
+                "analysisNotes": match_analysis.get("analysisNotes", []),
+                "confidence": match_analysis.get("confidence"),
+                "kickoff": match.get("date"),
+            }
+            gpt_summary = chatgpt.summarize_match(gpt_context)
+
+            message_text = build_response_message(match, match_analysis, gpt_summary)
+            telegram.send_message(message_text, chat_id=str(chat_id))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python_bot/requirements.txt
+++ b/python_bot/requirements.txt
@@ -1,2 +1,3 @@
 python-dotenv>=1.0.0
 requests>=2.32.0
+beautifulsoup4>=4.12.0

--- a/src/mastra/tools/analyzeOddsAndMarkets.ts
+++ b/src/mastra/tools/analyzeOddsAndMarkets.ts
@@ -15,6 +15,122 @@ type AnalyzedMatch = any & {
   };
   confidence: "low" | "medium" | "high";
   recommendedBets: string[];
+  analysisNotes?: string[];
+};
+
+type TeamFormSummary = {
+  currentStreak?: { type?: string; count?: number } | null;
+  recentRecord?: string;
+  avgGoalsFor?: number;
+  avgGoalsAgainst?: number;
+  goalDifferenceAvg?: number;
+  winRate?: number;
+  drawRate?: number;
+  lossRate?: number;
+};
+
+type HeadToHeadSummary = {
+  homeWins?: number;
+  awayWins?: number;
+  draws?: number;
+  avgGoalsTotal?: number;
+} | null;
+
+const normalizeMarketValue = (value: unknown): string => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  return value
+    .toString()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[,]/g, ".")
+    .replace(/[()]/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+};
+
+const HOME_LABELS = new Set([
+  "home",
+  "1",
+  "home team",
+  "team 1",
+  "1 home",
+]);
+
+const DRAW_LABELS = new Set([
+  "draw",
+  "x",
+  "empate",
+]);
+
+const AWAY_LABELS = new Set([
+  "away",
+  "2",
+  "away team",
+  "team 2",
+  "2 away",
+]);
+
+const YES_LABELS = new Set([
+  "yes",
+  "sim",
+  "y",
+  "s",
+]);
+
+const NO_LABELS = new Set([
+  "no",
+  "nao",
+  "n",
+]);
+
+const MARKET_ALIASES = new Map<string, Set<string>>([
+  [
+    "match_winner",
+    new Set(["match winner", "1x2", "full time result", "match result", "result", "win-draw-win"]),
+  ],
+  [
+    "goals_over_under",
+    new Set(["goals over/under", "over/under", "goals", "goals o/u", "total goals"]),
+  ],
+  [
+    "both_teams_score",
+    new Set(["both teams score", "both teams to score", "btts", "gg/ng", "goal goal"]),
+  ],
+]);
+
+const normalizeMarketName = (value: unknown): string => {
+  const normalized = normalizeMarketValue(value);
+  if (!normalized) return "";
+  for (const [key, aliases] of MARKET_ALIASES.entries()) {
+    if (aliases.has(normalized)) return key;
+  }
+  return normalized;
+};
+
+const isOver25Label = (value: unknown): boolean => {
+  const normalized = normalizeMarketValue(value);
+  if (!normalized) return false;
+
+  if (normalized.includes("over") || normalized.includes("mais de")) {
+    return normalized.includes("2.5") || normalized.includes("25");
+  }
+
+  return false;
+};
+
+const isUnder25Label = (value: unknown): boolean => {
+  const normalized = normalizeMarketValue(value);
+  if (!normalized) return false;
+
+  if (normalized.includes("under") || normalized.includes("menos de")) {
+    return normalized.includes("2.5") || normalized.includes("25");
+  }
+
+  return false;
 };
 
 const analyzeMatchOdds = ({
@@ -45,26 +161,43 @@ const analyzeMatchOdds = ({
       },
       recommendedBets: [] as string[],
       confidence: "low" as "low" | "medium" | "high",
+      analysisNotes: [] as string[],
     };
 
     if (!match.odds || match.odds.length === 0) {
-      logger?.warn("📝 [AnalyzeOddsAndMarkets] No odds available for match", { 
-        fixtureId: match.fixtureId 
+      logger?.warn("📝 [AnalyzeOddsAndMarkets] No odds available for match", {
+        fixtureId: match.fixtureId
       });
       return analysis;
     }
 
     try {
+      const marketMap = new Map<string, any[]>();
+      const forebet = match.forebet ?? null;
+      let forebetUsed = false;
+      for (const market of match.odds) {
+        const key = normalizeMarketName(market?.name);
+        if (!key) continue;
+        const values = Array.isArray(market?.values) ? market.values : [];
+        if (!marketMap.has(key) || !(marketMap.get(key)?.length > 0)) {
+          marketMap.set(key, values);
+        }
+      }
+
       // Find different betting markets
-      const matchWinnerBet = match.odds.find((bet: any) => bet.name === "Match Winner");
-      const overUnderBet = match.odds.find((bet: any) => bet.name === "Goals Over/Under");
-      const bttsBet = match.odds.find((bet: any) => bet.name === "Both Teams Score");
+      const matchWinnerBet = marketMap.get("match_winner");
+      const overUnderBet = marketMap.get("goals_over_under");
+      const bttsBet = marketMap.get("both_teams_score");
 
       // Convert odds to probabilities (probability = 1 / decimal_odds)
-      if (matchWinnerBet && matchWinnerBet.values) {
-        const homeOdd = parseFloat(matchWinnerBet.values.find((v: any) => v.value === "Home")?.odd || "0");
-        const drawOdd = parseFloat(matchWinnerBet.values.find((v: any) => v.value === "Draw")?.odd || "0");
-        const awayOdd = parseFloat(matchWinnerBet.values.find((v: any) => v.value === "Away")?.odd || "0");
+      if (matchWinnerBet) {
+        const homeEntry = matchWinnerBet.find((v: any) => HOME_LABELS.has(normalizeMarketValue(v.value)));
+        const drawEntry = matchWinnerBet.find((v: any) => DRAW_LABELS.has(normalizeMarketValue(v.value)));
+        const awayEntry = matchWinnerBet.find((v: any) => AWAY_LABELS.has(normalizeMarketValue(v.value)));
+
+        const homeOdd = parseFloat(homeEntry?.odd ?? "0");
+        const drawOdd = parseFloat(drawEntry?.odd ?? "0");
+        const awayOdd = parseFloat(awayEntry?.odd ?? "0");
 
         if (homeOdd > 0) analysis.predictions.homeWinProbability = Math.round((1 / homeOdd) * 100);
         if (drawOdd > 0) analysis.predictions.drawProbability = Math.round((1 / drawOdd) * 100);
@@ -78,9 +211,12 @@ const analyzeMatchOdds = ({
       }
 
       // Over/Under 2.5 goals analysis
-      if (overUnderBet && overUnderBet.values) {
-        const over25Odd = parseFloat(overUnderBet.values.find((v: any) => v.value === "Over 2.5")?.odd || "0");
-        const under25Odd = parseFloat(overUnderBet.values.find((v: any) => v.value === "Under 2.5")?.odd || "0");
+      if (overUnderBet) {
+        const overEntry = overUnderBet.find((v: any) => isOver25Label(v.value));
+        const underEntry = overUnderBet.find((v: any) => isUnder25Label(v.value));
+
+        const over25Odd = parseFloat(overEntry?.odd ?? "0");
+        const under25Odd = parseFloat(underEntry?.odd ?? "0");
 
         if (over25Odd > 0) analysis.predictions.over25Probability = Math.round((1 / over25Odd) * 100);
         if (under25Odd > 0) analysis.predictions.under25Probability = Math.round((1 / under25Odd) * 100);
@@ -92,9 +228,12 @@ const analyzeMatchOdds = ({
       }
 
       // Both Teams to Score (BTTS) analysis
-      if (bttsBet && bttsBet.values) {
-        const bttsYesOdd = parseFloat(bttsBet.values.find((v: any) => v.value === "Yes")?.odd || "0");
-        const bttsNoOdd = parseFloat(bttsBet.values.find((v: any) => v.value === "No")?.odd || "0");
+      if (bttsBet) {
+        const yesEntry = bttsBet.find((v: any) => YES_LABELS.has(normalizeMarketValue(v.value)));
+        const noEntry = bttsBet.find((v: any) => NO_LABELS.has(normalizeMarketValue(v.value)));
+
+        const bttsYesOdd = parseFloat(yesEntry?.odd ?? "0");
+        const bttsNoOdd = parseFloat(noEntry?.odd ?? "0");
 
         if (bttsYesOdd > 0) analysis.predictions.bttsYesProbability = Math.round((1 / bttsYesOdd) * 100);
         if (bttsNoOdd > 0) analysis.predictions.bttsNoProbability = Math.round((1 / bttsNoOdd) * 100);
@@ -103,6 +242,29 @@ const analyzeMatchOdds = ({
           bttsYes: analysis.predictions.bttsYesProbability,
           bttsNo: analysis.predictions.bttsNoProbability
         });
+      }
+
+      if (forebet) {
+        const applyForebet = (
+          sourceKey: string,
+          targetKey: keyof typeof analysis.predictions,
+        ) => {
+          const current = analysis.predictions[targetKey];
+          if (current && current > 0) return;
+          const raw = Number(forebet[sourceKey as keyof typeof forebet]);
+          if (Number.isFinite(raw) && raw > 0) {
+            analysis.predictions[targetKey] = Math.max(0, Math.min(100, Math.round(raw)));
+            forebetUsed = true;
+          }
+        };
+
+        applyForebet("homeWinProbability", "homeWinProbability");
+        applyForebet("drawProbability", "drawProbability");
+        applyForebet("awayWinProbability", "awayWinProbability");
+        applyForebet("over25Probability", "over25Probability");
+        applyForebet("under25Probability", "under25Probability");
+        applyForebet("bttsYesProbability", "bttsYesProbability");
+        applyForebet("bttsNoProbability", "bttsNoProbability");
       }
 
       // Generate recommendations based on probability analysis
@@ -147,8 +309,90 @@ const analyzeMatchOdds = ({
         totalConfidence += 1;
       }
 
+      const notes: string[] = [];
+      let qualitativeBoost = 0;
+
+      const homeForm = (match.form?.home ?? null) as TeamFormSummary | null;
+      const awayForm = (match.form?.away ?? null) as TeamFormSummary | null;
+      const headToHead = (match.form?.headToHead ?? null) as HeadToHeadSummary;
+
+      const summarizeRecord = (record?: string) => (record ?? "").slice(0, 5);
+
+      if (homeForm?.currentStreak?.type === "win" && (homeForm.currentStreak.count ?? 0) >= 3) {
+        notes.push(
+          `Casa com ${homeForm.currentStreak.count} vitórias seguidas (${summarizeRecord(homeForm.recentRecord)})`,
+        );
+        qualitativeBoost += 1;
+      }
+
+      if (awayForm?.currentStreak?.type === "loss" && (awayForm.currentStreak.count ?? 0) >= 2) {
+        notes.push(
+          `Visitante sem vencer há ${awayForm.currentStreak.count} jogos (${summarizeRecord(awayForm.recentRecord)})`,
+        );
+        qualitativeBoost += 1;
+      }
+
+      const avgAttack = (homeForm?.avgGoalsFor ?? 0) + (awayForm?.avgGoalsFor ?? 0);
+      if (avgAttack >= 3.2) {
+        notes.push("Tendência de muitos golos (médias ofensivas altas nas últimas partidas)");
+      } else if (avgAttack <= 2.0) {
+        notes.push("Tendência de poucos golos nos últimos jogos das equipas");
+      }
+
+      if ((headToHead?.homeWins ?? 0) >= 3) {
+        notes.push("Histórico recente favorável ao mandante no confronto direto");
+        qualitativeBoost += 1;
+      }
+
+      if ((headToHead?.avgGoalsTotal ?? 0) >= 3) {
+        notes.push("Confrontos diretos recentes com média superior a 3 golos");
+      }
+
+      if (forebetUsed) {
+        notes.push("Probabilidades 1X2 complementadas com dados da Forebet");
+      }
+
+      analysis.analysisNotes = notes.slice(0, 3);
+
+      const formCount = (homeForm ? 1 : 0) + (awayForm ? 1 : 0) || 1;
+      const drawRate = ((homeForm?.drawRate ?? 0) + (awayForm?.drawRate ?? 0)) / formCount;
+      const shouldBackfillProbabilities =
+        analysis.predictions.homeWinProbability === 0 &&
+        analysis.predictions.awayWinProbability === 0 &&
+        analysis.predictions.drawProbability === 0 &&
+        (homeForm || awayForm);
+
+      if (shouldBackfillProbabilities) {
+        const drawProbability = Math.round(Math.min(drawRate, 0.45) * 100);
+        const homeScore =
+          (homeForm?.winRate ?? 0) +
+          Math.max(homeForm?.goalDifferenceAvg ?? 0, 0) +
+          (awayForm?.lossRate ?? 0) * 0.6;
+        const awayScore =
+          (awayForm?.winRate ?? 0) +
+          Math.max(awayForm?.goalDifferenceAvg ?? 0, 0) +
+          (homeForm?.lossRate ?? 0) * 0.6;
+
+        const total = homeScore + awayScore;
+        const available = Math.max(0, 100 - drawProbability);
+
+        if (total > 0) {
+          analysis.predictions.homeWinProbability = Math.round((homeScore / total) * available);
+          analysis.predictions.awayWinProbability = Math.max(
+            0,
+            available - analysis.predictions.homeWinProbability,
+          );
+        } else {
+          analysis.predictions.homeWinProbability = Math.round(available / 2);
+          analysis.predictions.awayWinProbability = available - analysis.predictions.homeWinProbability;
+        }
+
+        analysis.predictions.drawProbability = drawProbability;
+      }
+
+      totalConfidence += qualitativeBoost;
       analysis.recommendedBets = recommendations;
-      
+
       // Determine overall confidence
       if (totalConfidence >= 5) {
         analysis.confidence = "high";
@@ -176,8 +420,19 @@ const analyzeMatchOdds = ({
 
   // Sort matches by confidence and probability strength
   const confidenceScore: Record<string, number> = { high: 3, medium: 2, low: 1 };
-  const computeScore = (match: AnalyzedMatch) =>
-    (confidenceScore[match.confidence] || 0) * 10 + (match.recommendedBets?.length || 0);
+  const computeScore = (match: AnalyzedMatch) => {
+    const predictions = match.predictions ?? {};
+    const maxProbability = Math.max(
+      Number(predictions.homeWinProbability ?? 0),
+      Number(predictions.drawProbability ?? 0),
+      Number(predictions.awayWinProbability ?? 0),
+    );
+    return (
+      (confidenceScore[match.confidence] || 0) * 1000 +
+      (match.recommendedBets?.length || 0) * 10 +
+      maxProbability
+    );
+  };
 
   const sortedMatches = analyzedMatches.sort((a, b) => computeScore(b) - computeScore(a));
 

--- a/src/mastra/tools/fetchFootballMatches.ts
+++ b/src/mastra/tools/fetchFootballMatches.ts
@@ -10,6 +10,137 @@ import {
   REGION_ORDER,
 } from "../constants/competitions";
 
+const decodeHtml = (value: string | null | undefined): string => {
+  if (!value) return "";
+  return value
+    .replace(/<br\s*\/?\s*>/gi, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .trim();
+};
+
+const buildForebetKey = (home: string | null | undefined, away: string | null | undefined): string | null => {
+  const normalize = (text: string | null | undefined) =>
+    (text ?? "")
+      .normalize("NFD")
+      .replace(/\p{Diacritic}/gu, "")
+      .replace(/[^a-z0-9]+/gi, " ")
+      .trim()
+      .toLowerCase();
+
+  const homeKey = normalize(home);
+  const awayKey = normalize(away);
+  if (!homeKey || !awayKey) return null;
+  return `${homeKey}|${awayKey}`;
+};
+
+const parsePercentages = (text: string): number[] => {
+  const matches = [...text.matchAll(/(-?\d+(?:\.\d+)?)\s*%/g)];
+  return matches.map((match) => Number(match[1]));
+};
+
+const parseForebetHtml = (html: string, logger?: IMastraLogger) => {
+  const results = new Map<string, Record<string, number | string | undefined>>();
+  if (!html) return results;
+
+  const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+  let rowMatch: RegExpExecArray | null;
+  while ((rowMatch = rowRegex.exec(html)) !== null) {
+    const rowHtml = rowMatch[1];
+    const cellRegex = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+    const cells: string[] = [];
+    let cellMatch: RegExpExecArray | null;
+    while ((cellMatch = cellRegex.exec(rowHtml)) !== null) {
+      cells.push(decodeHtml(cellMatch[1]));
+    }
+
+    if (cells.length < 3) continue;
+
+    let homeTeam = null as string | null;
+    let awayTeam = null as string | null;
+
+    const homeMatch = rowHtml.match(/class="[^"]*(home|tnms|team1)[^"]*"[^>]*>([\s\S]*?)<\/td>/i);
+    const awayMatch = rowHtml.match(/class="[^"]*(away|tnms2|team2)[^"]*"[^>]*>([\s\S]*?)<\/td>/i);
+
+    if (homeMatch) homeTeam = decodeHtml(homeMatch[2]);
+    if (awayMatch) awayTeam = decodeHtml(awayMatch[2]);
+
+    if (!homeTeam || !awayTeam) {
+      homeTeam = homeTeam || cells[1] || null;
+      awayTeam = awayTeam || cells[2] || null;
+    }
+
+    if (!homeTeam || !awayTeam) continue;
+
+    const percentages = cells.flatMap((cell) => parsePercentages(cell));
+    if (percentages.length < 3) continue;
+
+    const key = buildForebetKey(homeTeam, awayTeam);
+    if (!key || results.has(key)) continue;
+
+    const [homeProb, drawProb, awayProb] = percentages;
+    const overProb = percentages[3];
+    const underProb = percentages[4];
+    const bttsYes = percentages[5];
+    const bttsNo = percentages[6];
+
+    results.set(key, {
+      source: "Forebet",
+      homeWinProbability: Math.round(homeProb ?? 0),
+      drawProbability: Math.round(drawProb ?? 0),
+      awayWinProbability: Math.round(awayProb ?? 0),
+      over25Probability: overProb !== undefined ? Math.round(overProb) : undefined,
+      under25Probability: underProb !== undefined ? Math.round(underProb) : undefined,
+      bttsYesProbability: bttsYes !== undefined ? Math.round(bttsYes) : undefined,
+      bttsNoProbability: bttsNo !== undefined ? Math.round(bttsNo) : undefined,
+    });
+  }
+
+  logger?.info("📝 [FetchFootballMatches] Parsed Forebet predictions", { total: results.size });
+  return results;
+};
+
+const fetchForebetPredictions = async (date: string, logger?: IMastraLogger) => {
+  try {
+    const target = new Date(`${date}T00:00:00Z`);
+    const now = new Date();
+    const isToday =
+      target.getUTCFullYear() === now.getUTCFullYear() &&
+      target.getUTCMonth() === now.getUTCMonth() &&
+      target.getUTCDate() === now.getUTCDate();
+    const slug = isToday ? "today" : date;
+    const response = await fetch(
+      `https://www.forebet.com/en/football-tips-and-predictions-for-${slug}`,
+      {
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+          "Accept-Language": "en-US,en;q=0.9",
+        },
+      },
+    );
+
+    if (!response.ok) {
+      logger?.warn("📝 [FetchFootballMatches] Forebet request failed", { status: response.status });
+      return new Map<string, Record<string, number | string | undefined>>();
+    }
+
+    const html = await response.text();
+    return parseForebetHtml(html, logger);
+  } catch (error) {
+    logger?.warn("📝 [FetchFootballMatches] Unable to fetch Forebet predictions", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return new Map<string, Record<string, number | string | undefined>>();
+  }
+};
+
 const fetchFootballMatchesFromAPI = async ({
   date,
   logger,
@@ -72,6 +203,7 @@ const fetchFootballMatchesFromAPI = async ({
     }
 
     const matches: any[] = [];
+    const forebetPredictions = await fetchForebetPredictions(date, logger);
 
     const regionCounters: Record<string, { total: number }> = {};
     REGION_ORDER.forEach((region) => {
@@ -98,7 +230,7 @@ const fetchFootballMatchesFromAPI = async ({
 
         // Fetch odds for this specific match
         const oddsResponse = await fetch(
-          `https://v3.football.api-sports.io/odds?fixture=${fixture.fixture.id}&bookmaker=6`, // Bet365
+          `https://v3.football.api-sports.io/odds?fixture=${fixture.fixture.id}`,
           {
             headers: {
               "X-RapidAPI-Key": apiKey,
@@ -111,10 +243,27 @@ const fetchFootballMatchesFromAPI = async ({
         if (oddsResponse.ok) {
           const oddsData = await oddsResponse.json();
           if (oddsData.response && oddsData.response.length > 0) {
-            odds = oddsData.response[0].bookmakers[0]?.bets || [];
-            logger?.info("📝 [FetchFootballMatches] Retrieved odds", { 
+            const bookmakers = oddsData.response[0]?.bookmakers ?? [];
+            const preferredId = Number(process.env.FOOTBALL_API_BOOKMAKER || "6");
+            const ordered = [
+              ...bookmakers.filter((bookmaker: any) => bookmaker.id === preferredId),
+              ...bookmakers.filter((bookmaker: any) => bookmaker.id !== preferredId),
+            ];
+
+            const marketMap = new Map<string, any[]>();
+            for (const bookmaker of ordered) {
+              for (const bet of bookmaker?.bets ?? []) {
+                if (!bet?.name) continue;
+                if (!marketMap.has(bet.name) || !(marketMap.get(bet.name)?.length > 0)) {
+                  marketMap.set(bet.name, bet.values ?? []);
+                }
+              }
+            }
+
+            odds = Array.from(marketMap.entries()).map(([name, values]) => ({ name, values }));
+            logger?.info("📝 [FetchFootballMatches] Retrieved odds", {
               fixtureId: fixture.fixture.id,
-              oddsCount: odds.length 
+              oddsCount: odds.length
             });
           }
         } else {
@@ -123,6 +272,12 @@ const fetchFootballMatchesFromAPI = async ({
             status: oddsResponse.status 
           });
         }
+
+        const forebetKey = buildForebetKey(
+          fixture.teams?.home?.name,
+          fixture.teams?.away?.name,
+        );
+        const forebet = forebetKey ? forebetPredictions.get(forebetKey) ?? null : null;
 
         matches.push({
           fixtureId: fixture.fixture.id,
@@ -154,7 +309,8 @@ const fetchFootballMatchesFromAPI = async ({
             },
           },
           venue: fixture.fixture.venue?.name || "TBD",
-          odds: odds,
+          odds,
+          forebet,
         });
 
         if (!regionCounters[competition.region]) {

--- a/src/mastra/workflows/footballPredictionsWorkflow.ts
+++ b/src/mastra/workflows/footballPredictionsWorkflow.ts
@@ -187,6 +187,9 @@ const sendPredictionsStep = createStep({
         if (match.predictions) {
           message += `📈 Prob: Casa ${match.predictions.homeWinProbability}% | Empate ${match.predictions.drawProbability}% | Fora ${match.predictions.awayWinProbability}%\n`;
         }
+        if (match.analysisNotes && match.analysisNotes.length > 0) {
+          message += `📝 PK: ${match.analysisNotes.slice(0, 2).join(' • ')}\n`;
+        }
         message += `\n`;
       });
     }
@@ -222,6 +225,9 @@ const sendPredictionsStep = createStep({
               if (predictions.bttsYesProbability > 0 || predictions.bttsNoProbability > 0) {
                 message += `🥅 BTTS: Sim ${predictions.bttsYesProbability}% | Não ${predictions.bttsNoProbability}%\n`;
               }
+            }
+            if (match.analysisNotes && match.analysisNotes.length > 0) {
+              message += `📝 PK: ${match.analysisNotes.slice(0, 2).join(' • ')}\n`;
             }
 
             message += `\n`;


### PR DESCRIPTION
## Summary
- merge bookmaker markets and normalize additional aliases so 1X2, Over/Under 2.5 and BTTS percentages populate consistently across Python, Node, and Mastra analyzers
- add a Forebet-backed scraper to capture fallback probabilities for fixtures without complete odds data and surface those notes in match analysis
- document the Forebet signal usage in the README and include the new dependency in the Python requirements list

## Testing
- python -m compileall python_bot
- npm run check *(fails: Mastra/TypeScript dependencies are not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e63070b5708325b20232c658e110f1