### PR TITLE
Improve live alerts and match messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ FOOTBALL_MAX_FIXTURES=120
 4. **Executar diariamente automaticamente:** use um agendador do sistema:
    * **Linux/macOS:** `crontab -e` → `0 9 * * * /caminho/para/.venv/bin/python -m python_bot.main --env /caminho/para/.env`
    * **Windows:** Agendador de Tarefas apontando para `python.exe -m python_bot.main --env C:\caminho\.env`
+   * Alternativa embutida: `python -m python_bot.scheduler --env .env --time 00:10 --timezone Europe/Lisbon`
+
+5. **Alertas em jogos ao vivo:**
+   ```bash
+   python -m python_bot.live_monitor --env .env --interval 180 --min-confidence medium
+   ```
+   O monitor envia apenas novas recomendações ou elevações de confiança para evitar alertas repetidos.
 
 ### Node.js
 

--- a/python_bot/README.md
+++ b/python_bot/README.md
@@ -39,3 +39,28 @@ python -m python_bot.main --env .env
 Use `--date YYYY-MM-DD` to backfill a specific day, `--chat-id` to override the destination, and `--output` to export the raw JSON payload.
 
 The bot shares the competition metadata stored in `shared/competitions.json`, which is extracted directly from the TypeScript implementation.
+
+## Execução automática diária
+
+Uma rotina para enviar o relatório principal todos os dias às 00:10 está disponível no módulo `python_bot.scheduler`:
+
+```bash
+python -m python_bot.scheduler --env .env --timezone Europe/Lisbon --time 00:10
+```
+
+Argumentos úteis:
+
+- `--chat-id`: substitui o chat padrão configurado no `.env`.
+- `--run-immediately`: dispara uma execução assim que o script inicia, além do agendamento diário.
+- `--time HH:MM`: ajusta o horário alvo (padrão `00:10`).
+- `--timezone`: fuso IANA usado para calcular o horário local (padrão `UTC`).
+
+## Monitor de jogos ao vivo
+
+Para receber alertas em tempo real quando surgirem novas recomendações durante as partidas, utilize o módulo `python_bot.live_monitor`:
+
+```bash
+python -m python_bot.live_monitor --env .env --interval 180 --min-confidence medium
+```
+
+O monitor consulta a API a cada `--interval` segundos (mínimo 30s), analisa os jogos em andamento e envia notificações quando surgir uma recomendação inédita, quando a confiança subir para o patamar configurado (`low`, `medium`, `high`) **ou** sempre que um novo golo for marcado. Use `--dry-run` para testar no terminal sem enviar mensagens e `--chat-id` para direcionar os alertas para um destino específico.

--- a/python_bot/analyzer.py
+++ b/python_bot/analyzer.py
@@ -502,13 +502,15 @@ def analyze_matches(matches: List[Dict[str, object]], index: CompetitionIndex, l
             {
                 "region": region,
                 "label": index.region_label.get(region, region),
-                "matches": ordered[:5],
+                "matches": ordered,
+                "topMatches": ordered[:5],
             }
         )
 
     return {
         "totalAnalyzed": len(analyzed),
         "bestMatches": sorted_matches[:10],
+        "allMatches": sorted_matches,
         "highConfidenceCount": sum(1 for match in sorted_matches if match.get("confidence") == "high"),
         "mediumConfidenceCount": sum(1 for match in sorted_matches if match.get("confidence") == "medium"),
         "breakdownByRegion": breakdown,

--- a/python_bot/live_monitor.py
+++ b/python_bot/live_monitor.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from datetime import datetime, timezone
+from html import escape
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from .analyzer import analyze_matches
+from .competitions import load_index
+from .config import load_settings
+from .fetcher import FetchError, fetch_matches
+from .telegram_client import TelegramClient
+
+
+CONFIDENCE_RANK = {"low": 0, "medium": 1, "high": 2}
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Monitoriza partidas ao vivo e envia alertas de apostas")
+    parser.add_argument("--env", help="Caminho para o arquivo .env", default=None)
+    parser.add_argument("--chat-id", help="Chat ID opcional para envio", default=None)
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=180,
+        help="Intervalo em segundos entre varreduras (padrão 180s)",
+    )
+    parser.add_argument(
+        "--min-confidence",
+        choices=("low", "medium", "high"),
+        default="medium",
+        help="Nível mínimo de confiança para disparar alertas",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Não envia mensagens ao Telegram, apenas imprime os alertas",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Ativa logs detalhados")
+    return parser.parse_args(argv)
+
+
+def _confidence_label(confidence: Optional[str]) -> Optional[str]:
+    mapping = {"high": "🔥 Alta", "medium": "⚡ Média", "low": "💡 Baixa"}
+    if not confidence:
+        return None
+    return mapping.get(confidence, "💡 Baixa")
+
+
+def _format_probabilities(predictions: Dict[str, object]) -> List[str]:
+    lines: List[str] = []
+    home = int(predictions.get("homeWinProbability", 0) or 0)
+    draw = int(predictions.get("drawProbability", 0) or 0)
+    away = int(predictions.get("awayWinProbability", 0) or 0)
+    if any(value > 0 for value in (home, draw, away)):
+        lines.append(f"📈 1X2: Casa {home}% | Empate {draw}% | Fora {away}%")
+
+    over25 = int(predictions.get("over25Probability", 0) or 0)
+    under25 = int(predictions.get("under25Probability", 0) or 0)
+    if any(value > 0 for value in (over25, under25)):
+        lines.append(f"⚽ Linhas 2.5: Over {over25}% | Under {under25}%")
+
+    btts_yes = int(predictions.get("bttsYesProbability", 0) or 0)
+    btts_no = int(predictions.get("bttsNoProbability", 0) or 0)
+    if any(value > 0 for value in (btts_yes, btts_no)):
+        lines.append(f"🤝 Ambos marcam: Sim {btts_yes}% | Não {btts_no}%")
+
+    return lines
+
+
+class LiveMonitor:
+    def __init__(
+        self,
+        settings,
+        index,
+        *,
+        chat_id: Optional[str],
+        interval: int,
+        min_confidence: str,
+        dry_run: bool,
+        logger: logging.Logger,
+    ) -> None:
+        self.settings = settings
+        self.index = index
+        self.chat_id = chat_id
+        self.interval = max(30, interval)
+        self.min_rank = CONFIDENCE_RANK.get(min_confidence, 1)
+        self.dry_run = dry_run
+        self.logger = logger
+        self.client = None if dry_run else TelegramClient(settings, logger=logger)
+        self._sent_flags: Dict[int, Set[str]] = {}
+        self._score_cache: Dict[int, Tuple[int, int]] = {}
+
+    def _cleanup_finished(self, matches: List[Dict[str, object]]) -> None:
+        active_ids: Set[int] = set()
+        for match in matches:
+            fixture_id = match.get("fixtureId")
+            try:
+                fixture_key = int(fixture_id)
+            except (TypeError, ValueError):  # noqa: PERF203 - valores inesperados
+                continue
+            active_ids.add(fixture_key)
+
+        finished_status = {"FT", "AET", "PEN", "CANC", "ABD", "PST"}
+        for match in matches:
+            fixture_id = match.get("fixtureId")
+            try:
+                fixture_key = int(fixture_id)
+            except (TypeError, ValueError):
+                continue
+
+            status_short = str(((match.get("status") or {}) or {}).get("short") or "")
+            if status_short in finished_status and fixture_key in self._sent_flags:
+                self.logger.debug("Removendo cache de alerta para jogo finalizado", extra={"fixtureId": fixture_key})
+                self._sent_flags.pop(fixture_key, None)
+                self._score_cache.pop(fixture_key, None)
+        # Garanta que não guardamos jogos antigos sem status
+        for fixture_key in list(self._sent_flags):
+            if fixture_key not in active_ids:
+                self._sent_flags.pop(fixture_key, None)
+                self._score_cache.pop(fixture_key, None)
+
+    @staticmethod
+    def _coerce_score(value: Optional[object]) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):  # noqa: PERF203 - valores inesperados
+            return None
+
+    def _detect_goal(
+        self,
+        fixture_key: int,
+        match: Dict[str, object],
+        sent_flags: Set[str],
+    ) -> Tuple[Set[str], List[Dict[str, object]]]:
+        score = match.get("score") or {}
+        home = self._coerce_score((score or {}).get("home"))
+        away = self._coerce_score((score or {}).get("away"))
+
+        if home is None or away is None:
+            self._score_cache.pop(fixture_key, None)
+            return set(), []
+
+        previous = self._score_cache.get(fixture_key)
+        self._score_cache[fixture_key] = (home, away)
+
+        if previous is None or previous == (home, away):
+            return set(), []
+
+        flag_value = f"goal:{home}-{away}"
+        if flag_value in sent_flags:
+            return set(), []
+
+        diff_home = home - previous[0]
+        diff_away = away - previous[1]
+
+        scorer: Optional[str] = None
+        teams = match.get("teams") or {}
+        if diff_home > diff_away and diff_home > 0:
+            scorer = (teams.get("home") or {}).get("name")
+        elif diff_away > diff_home and diff_away > 0:
+            scorer = (teams.get("away") or {}).get("name")
+
+        event = {
+            "type": "goal",
+            "home": home,
+            "away": away,
+            "scorer": scorer,
+        }
+
+        return {flag_value}, [event]
+
+    def _should_alert(
+        self,
+        match: Dict[str, object],
+    ) -> Optional[Tuple[int, List[str], Set[str], List[Dict[str, object]]]]:
+        confidence = str(match.get("confidence") or "low")
+        rank = CONFIDENCE_RANK.get(confidence, 0)
+        meets_threshold = rank >= self.min_rank
+
+        fixture_id = match.get("fixtureId")
+        if fixture_id is None:
+            return None
+
+        try:
+            fixture_key = int(fixture_id)
+        except (TypeError, ValueError):
+            return None
+
+        sent_flags = self._sent_flags.setdefault(fixture_key, set())
+        recommendations = [str(item) for item in (match.get("recommendedBets") or [])]
+
+        new_flags: Set[str] = set()
+        events: List[Dict[str, object]] = []
+        if meets_threshold:
+            new_recommendations = [item for item in recommendations if item not in sent_flags]
+
+            if new_recommendations:
+                new_flags.update(new_recommendations)
+            elif rank >= CONFIDENCE_RANK["high"] and "__high__" not in sent_flags:
+                new_flags.add("__high__")
+                events.append({"type": "confidence", "level": confidence})
+
+        goal_flags, goal_events = self._detect_goal(fixture_key, match, sent_flags)
+        if goal_flags:
+            new_flags.update(goal_flags)
+            events.extend(goal_events)
+
+        if not new_flags:
+            return None
+
+        return fixture_key, recommendations, new_flags, events
+
+    def _format_message(
+        self,
+        match: Dict[str, object],
+        recommendations: List[str],
+        new_flags: Set[str],
+        events: List[Dict[str, object]],
+    ) -> str:
+        teams = match.get("teams", {})
+        home = escape(str((teams.get("home") or {}).get("name") or "Casa"))
+        away = escape(str((teams.get("away") or {}).get("name") or "Fora"))
+        competition = match.get("competition", {}) or {}
+        league = competition.get("name") or match.get("league", {}).get("name")
+        league_label = escape(str(league or "Competição"))
+
+        score = match.get("score") or {}
+        home_goals = score.get("home")
+        away_goals = score.get("away")
+        score_line = f"{home_goals if home_goals is not None else '?'}-{away_goals if away_goals is not None else '?'}"
+
+        status = match.get("status") or {}
+        elapsed = status.get("elapsed")
+        short = status.get("short") or "LIVE"
+
+        lines = ["🚨 <b>ALERTA AO VIVO</b>"]
+        lines.append(f"{home} {score_line} {away} — {league_label}")
+        if elapsed is not None:
+            lines.append(f"⏱️ {elapsed}' ({escape(str(short))})")
+        else:
+            lines.append(f"⏱️ Status: {escape(str(short))}")
+
+        confidence_text = _confidence_label(match.get("confidence"))
+        if confidence_text:
+            lines.append(f"Confiança atual: {confidence_text}")
+
+        goal_events = [event for event in events if event.get("type") == "goal"]
+        for event in goal_events:
+            scorer = event.get("scorer")
+            scorer_text = f" de {escape(str(scorer))}" if scorer else ""
+            lines.append(
+                f"⚽ Golo{scorer_text}! Placar atualizado: {event.get('home')}-{event.get('away')}"
+            )
+
+        if any(event.get("type") == "confidence" for event in events):
+            lines.append("🚀 Confiança elevada — oportunidades reforçadas!")
+
+        if new_flags:
+            actionable = [
+                flag
+                for flag in new_flags
+                if flag not in {"__high__"} and not flag.startswith("goal:")
+            ]
+            if actionable:
+                lines.append(
+                    f"🎯 Novas recomendações: {' | '.join(escape(entry) for entry in actionable)}"
+                )
+            elif recommendations:
+                lines.append(f"🎯 Recomendações: {' | '.join(escape(item) for item in recommendations)}")
+
+        predictions = match.get("predictions") or {}
+        if isinstance(predictions, dict):
+            lines.extend(_format_probabilities(predictions))
+
+        notes = match.get("analysisNotes") or []
+        if notes:
+            lines.append(f"📝 {' • '.join(escape(str(note)) for note in notes[:2])}")
+
+        return "\n".join(lines)
+
+    def _send(self, message: str) -> None:
+        if self.dry_run:
+            print(message)
+            print("-" * 80)
+            return
+
+        if not self.client:
+            return
+
+        self.client.send_message(message, chat_id=self.chat_id)
+
+    def run(self) -> None:
+        self.logger.info(
+            "Monitor live iniciado (intervalo=%ss, min_confidence=%s)",
+            self.interval,
+            self.min_rank,
+        )
+
+        while True:
+            try:
+                match_data = fetch_matches(
+                    datetime.now(timezone.utc),
+                    self.settings,
+                    self.index,
+                    logger=self.logger,
+                    status="LIVE",
+                )
+            except FetchError as exc:
+                self.logger.error("Falha ao buscar jogos ao vivo: %s", exc)
+                time.sleep(self.interval)
+                continue
+
+            matches = match_data.get("matches", []) or []
+            self._cleanup_finished(matches)
+
+            if not matches:
+                self.logger.debug("Nenhum jogo ao vivo nas competições monitorizadas")
+                time.sleep(self.interval)
+                continue
+
+            analysis = analyze_matches(matches, self.index, logger=self.logger)
+            analyzed_matches = analysis.get("allMatches", []) or []
+
+            for match in analyzed_matches:
+                result = self._should_alert(match)
+                if not result:
+                    continue
+
+                fixture_id, recommendations, new_flags, events = result
+                message = self._format_message(match, recommendations, new_flags, events)
+                try:
+                    self._send(message)
+                    self._sent_flags.setdefault(fixture_id, set()).update(new_flags)
+                    self.logger.info(
+                        "Alerta enviado", extra={"fixtureId": fixture_id, "flags": list(new_flags)}
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    self.logger.error("Falha ao enviar alerta ao vivo", exc_info=exc)
+
+            time.sleep(self.interval)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    logger = logging.getLogger("python-bot.live-monitor")
+
+    try:
+        settings = load_settings(Path(args.env) if args.env else None)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Não foi possível carregar configurações: %s", exc)
+        return 1
+
+    index = load_index()
+
+    monitor = LiveMonitor(
+        settings,
+        index,
+        chat_id=args.chat_id,
+        interval=args.interval,
+        min_confidence=args.min_confidence,
+        dry_run=args.dry_run,
+        logger=logger,
+    )
+
+    monitor.run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/python_bot/message_builder.py
+++ b/python_bot/message_builder.py
@@ -1,7 +1,83 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict
+from html import escape
+from typing import Dict, Iterable, List, Optional
+
+
+def _confidence_label(confidence: Optional[str]) -> Optional[str]:
+    mapping = {"high": "🔥 Alta", "medium": "⚡ Média", "low": "💡 Baixa"}
+    if not confidence:
+        return None
+    return mapping.get(confidence, "💡 Baixa")
+
+
+def _format_probability_lines(predictions: Dict[str, object]) -> List[str]:
+    lines: List[str] = []
+
+    home = int(predictions.get("homeWinProbability", 0) or 0)
+    draw = int(predictions.get("drawProbability", 0) or 0)
+    away = int(predictions.get("awayWinProbability", 0) or 0)
+
+    if any(value > 0 for value in (home, draw, away)):
+        lines.append(
+            f"↳ 📈 1X2: Casa {home}% | Empate {draw}% | Fora {away}%"
+        )
+
+    over25 = int(predictions.get("over25Probability", 0) or 0)
+    under25 = int(predictions.get("under25Probability", 0) or 0)
+    if any(value > 0 for value in (over25, under25)):
+        lines.append(f"↳ ⚽ Linhas 2.5: Over {over25}% | Under {under25}%")
+
+    btts_yes = int(predictions.get("bttsYesProbability", 0) or 0)
+    btts_no = int(predictions.get("bttsNoProbability", 0) or 0)
+    if any(value > 0 for value in (btts_yes, btts_no)):
+        lines.append(f"↳ 🤝 Ambos marcam: Sim {btts_yes}% | Não {btts_no}%")
+
+    return lines
+
+
+def _escape_join(values: Iterable[object], separator: str = " | ") -> str:
+    escaped = [escape(str(value)) for value in values if value is not None]
+    return separator.join(escaped)
+
+
+def _format_match_details(match: Dict[str, object], *, prefix: str) -> List[str]:
+    teams = match.get("teams", {})
+    home = escape(str((teams.get("home") or {}).get("name") or "Casa"))
+    away = escape(str((teams.get("away") or {}).get("name") or "Fora"))
+    competition = match.get("competition", {}) or {}
+    league = competition.get("name") or match.get("league", {}).get("name")
+    league_label = escape(str(league)) if league else ""
+    time_label = escape(str(match.get("time") or "TBD"))
+
+    header_parts = [prefix, f"<b>{home} vs {away}</b>"]
+    if time_label and time_label != "TBD":
+        header_parts.append(f"({time_label})")
+    if league_label:
+        header_parts.append(f"— {league_label}")
+
+    lines: List[str] = [" ".join(part for part in header_parts if part)]
+
+    confidence = _confidence_label(match.get("confidence"))
+    if confidence:
+        lines.append(f"↳ Confiança: {confidence}")
+
+    bets = match.get("recommendedBets") or []
+    if bets:
+        lines.append(f"↳ 🎯 {_escape_join(bets)}")
+    else:
+        lines.append("↳ 🎯 Sem recomendação automática — avaliar manualmente")
+
+    predictions = match.get("predictions") or {}
+    if isinstance(predictions, dict):
+        lines.extend(_format_probability_lines(predictions))
+
+    notes = match.get("analysisNotes") or []
+    if notes:
+        lines.append(f"↳ 📝 {_escape_join(notes[:2], ' • ')}")
+
+    return lines
 
 
 def format_predictions_message(match_data: Dict[str, object], analysis: Dict[str, object]) -> str:
@@ -27,48 +103,59 @@ def format_predictions_message(match_data: Dict[str, object], analysis: Dict[str
     if active_regions:
         message_lines.append("🌍 <b>Distribuição por Região:</b>")
         for region in active_regions:
-            label = region.get("label")
+            label = escape(str(region.get("label") or region.get("region") or ""))
             total = region.get("total", 0)
             high = region.get("highConfidence", 0)
             medium = region.get("mediumConfidence", 0)
             message_lines.append(f"• {label}: {total} jogos ({high} alta | {medium} média)")
         message_lines.append("")
 
-    best_matches = analysis.get("bestMatches", [])
+    best_matches = analysis.get("bestMatches", []) or []
     if best_matches:
         top_matches = best_matches[: min(5, len(best_matches))]
         message_lines.append(f"🔥 <b>TOP GLOBAL ({len(top_matches)})</b>")
         for match in top_matches:
             confidence = match.get("confidence")
             emoji = "🔥" if confidence == "high" else "⚡" if confidence == "medium" else "💡"
-            teams = match.get("teams", {})
-            competition = match.get("competition", {})
-            league_name = competition.get("name") or match.get("league", {}).get("name")
-            message_lines.append(
-                f"{emoji} <b>{teams.get('home', {}).get('name')} vs {teams.get('away', {}).get('name')}</b> — {league_name}"
-            )
-            if match.get("time"):
-                message_lines.append(f"⏰ {match['time']} | 🏆 {league_name}")
-            bets = match.get("recommendedBets", [])
-            if bets:
-                message_lines.append(f"🎯 {' | '.join(bets)}")
-            predictions = match.get("predictions", {})
-            if predictions:
-                message_lines.append(
-                    "📈 Prob: Casa {home}% | Empate {draw}% | Fora {away}%".format(
-                        home=predictions.get("homeWinProbability", 0),
-                        draw=predictions.get("drawProbability", 0),
-                        away=predictions.get("awayWinProbability", 0),
-                    )
-                )
-            notes = match.get("analysisNotes") or []
-            if notes:
-                message_lines.append(f"📝 PK: {' • '.join(notes[:2])}")
+            lines = _format_match_details(match, prefix=emoji)
+            time_value = match.get("time")
+            competition = match.get("competition", {}) or {}
+            league_label = competition.get("name") or match.get("league", {}).get("name")
+            if time_value:
+                lines.insert(1, f"↳ ⏰ {escape(str(time_value))} | 🏆 {escape(str(league_label or 'Horário a definir'))}")
+            message_lines.extend(lines)
             message_lines.append("")
     else:
         message_lines.append("😔 <b>Não há jogos com odds interessantes hoje.</b>")
         message_lines.append("Voltamos amanhã com mais análises!")
         message_lines.append("")
         message_lines.append("📈 Tip: Verifique os jogos ao vivo durante o dia para oportunidades em tempo real.")
+
+    regional_matches = analysis.get("bestMatchesByRegion", []) or []
+    detailed_regions = [region for region in regional_matches if region.get("matches")]
+    if detailed_regions:
+        message_lines.append("🗺️ <b>Lista completa por região/competição:</b>")
+        for region in detailed_regions:
+            label = escape(str(region.get("label") or region.get("region") or ""))
+            message_lines.append(f"📍 <b>{label}</b>")
+            for match in region.get("matches", []) or []:
+                message_lines.extend(_format_match_details(match, prefix="•"))
+                message_lines.append("")
+        if message_lines[-1] == "":
+            message_lines.pop()
+
+    message_lines.extend(
+        [
+            "",
+            "💡 <b>Lembre-se:</b>",
+            "• Aposte com responsabilidade",
+            "• Nunca aposte mais do que pode perder",
+            "• Estas são apenas previsões baseadas em probabilidades",
+            "",
+            "🔴 Lives: o bot monitoriza jogos em tempo real e envia alertas quentes via fluxo <i>live-betting</i>.",
+            "⚽ Boa sorte com as suas apostas!",
+            "🤖 Bot de Previsões Futebol",
+        ]
+    )
 
     return "\n".join(message_lines)

--- a/python_bot/scheduler.py
+++ b/python_bot/scheduler.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from datetime import date as date_cls
+from datetime import datetime, time as time_cls, timedelta
+from typing import List, Optional
+
+try:  # Python 3.9+
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - fallback for environments without zoneinfo
+    ZoneInfo = None  # type: ignore
+
+from .main import main as run_once
+
+
+def _parse_time(value: str) -> time_cls:
+    try:
+        parts = value.split(":")
+        if len(parts) not in {2, 3}:
+            raise ValueError
+        hour = int(parts[0])
+        minute = int(parts[1])
+        second = int(parts[2]) if len(parts) == 3 else 0
+        return time_cls(hour=hour, minute=minute, second=second)
+    except ValueError as exc:  # noqa: BLE001
+        raise argparse.ArgumentTypeError(
+            "Formato inválido para horário. Utilize HH:MM ou HH:MM:SS"
+        ) from exc
+
+
+def _next_run(now: datetime, target: time_cls) -> datetime:
+    candidate = now.replace(
+        hour=target.hour,
+        minute=target.minute,
+        second=target.second,
+        microsecond=0,
+    )
+    if candidate <= now:
+        candidate += timedelta(days=1)
+    return candidate
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+
+def _build_args(
+    base_args: argparse.Namespace,
+    run_date: date_cls,
+) -> List[str]:
+    argv: List[str] = ["--date", run_date.isoformat()]
+    if base_args.env:
+        argv.extend(["--env", base_args.env])
+    if base_args.chat_id:
+        argv.extend(["--chat-id", base_args.chat_id])
+    if base_args.dry_run:
+        argv.append("--dry-run")
+    if base_args.verbose:
+        argv.append("--verbose")
+    return argv
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Agenda execuções diárias do bot de previsões")
+    parser.add_argument("--env", help="Caminho para o arquivo .env", default=None)
+    parser.add_argument("--chat-id", help="Chat id opcional para sobrescrever o destino", default=None)
+    parser.add_argument(
+        "--time",
+        help="Horário diário no formato HH:MM (padrão 00:10)",
+        default="00:10",
+        type=_parse_time,
+    )
+    parser.add_argument(
+        "--timezone",
+        help="Timezone IANA para calcular o horário local (padrão UTC)",
+        default="UTC",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Executa o bot em modo dry-run (não envia mensagem)",
+    )
+    parser.add_argument(
+        "--run-immediately",
+        action="store_true",
+        help="Executa imediatamente antes de agendar o próximo ciclo",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Ativa logs em nível debug")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    _configure_logging(args.verbose)
+    logger = logging.getLogger("python-bot.scheduler")
+
+    tz = None
+    if ZoneInfo is not None:
+        try:
+            tz = ZoneInfo(args.timezone)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Timezone inválida: %s", args.timezone, exc_info=exc)
+            return 1
+    else:  # pragma: no cover - compatibilidade para Python < 3.9
+        logger.warning("zoneinfo não disponível; utilizando horário local do sistema")
+
+    def _now() -> datetime:
+        current = datetime.now(tz) if tz else datetime.now()
+        return current
+
+    def _execute(run_dt: datetime) -> None:
+        run_date = run_dt.date()
+        bot_args = _build_args(args, run_date)
+        logger.info("Executando bot para %s", run_date.isoformat())
+        exit_code = run_once(bot_args)
+        if exit_code != 0:
+            logger.error("Execução retornou código %s", exit_code)
+
+    if args.run_immediately:
+        logger.info("Execução imediata solicitada")
+        _execute(_now())
+
+    while True:
+        now = _now()
+        target = _next_run(now, args.time)
+        wait_seconds = max(1, int((target - now).total_seconds()))
+        logger.info(
+            "Próxima execução agendada para %s (em %.1f minutos)",
+            target.isoformat(),
+            wait_seconds / 60,
+        )
+        try:
+            time.sleep(wait_seconds)
+        except KeyboardInterrupt:  # pragma: no cover - interação manual
+            logger.info("Scheduler interrompido pelo utilizador")
+            return 0
+        _execute(target)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- extend the live monitor to track score changes, trigger goal alerts, and keep cache entries in sync
- ensure match breakdowns always mention the recommendation track, even when no automatic bet is suggested
- document that live alerts now fire on new goals in addition to recommendation/confidence updates

## Testing
- python -m compileall python_bot

------
https://chatgpt.com/codex/tasks/task_e_68e6805e37e883258ff0be6b2d7ae537